### PR TITLE
fix(web): fix sensor reactivity

### DIFF
--- a/web/src/lib/helpers.test.ts
+++ b/web/src/lib/helpers.test.ts
@@ -194,6 +194,12 @@ describe('helpers', () => {
 			expect(isSensorStale(ts, 3000)).toBe(true);
 			expect(isSensorStale(ts, 10_000)).toBe(false);
 		});
+
+		it('measures staleness against an injected now (so a ticking clock fades it)', () => {
+			const ts = new Date(1_000_000).toISOString();
+			expect(isSensorStale(ts, SENSOR_STALE_MS, 1_000_000 + SENSOR_STALE_MS - 1)).toBe(false);
+			expect(isSensorStale(ts, SENSOR_STALE_MS, 1_000_000 + SENSOR_STALE_MS + 1)).toBe(true);
+		});
 	});
 
 	describe('resolveOutsideTemp', () => {

--- a/web/src/lib/helpers.ts
+++ b/web/src/lib/helpers.ts
@@ -63,10 +63,15 @@ export function timeAgo(iso: string, now = Date.now()): string {
 // Threshold for treating a sensor reading as stale.
 export const SENSOR_STALE_MS = 10 * 60 * 1000;
 
-/** Returns true if the ISO timestamp is absent or older than maxAgeMs. */
-export function isSensorStale(timestamp: string | undefined, maxAgeMs = SENSOR_STALE_MS): boolean {
+// True if the timestamp is absent or older than maxAgeMs. `now` is injectable so a
+// reactive caller can pass a ticking clock (and for tests); defaults to the wall clock.
+export function isSensorStale(
+	timestamp: string | undefined,
+	maxAgeMs = SENSOR_STALE_MS,
+	now = Date.now()
+): boolean {
 	if (!timestamp) return true;
-	return Date.now() - new Date(timestamp).getTime() > maxAgeMs;
+	return now - new Date(timestamp).getTime() > maxAgeMs;
 }
 
 /**

--- a/web/src/routes/admin/components/SensorReadings.svelte
+++ b/web/src/routes/admin/components/SensorReadings.svelte
@@ -37,7 +37,7 @@
 <div class="grid grid-cols-[repeat(auto-fit,minmax(min(100%,10rem),1fr))] gap-2">
 	{#each rows as { key, sensor } (key)}
 		{const Icon = kindIcon(sensor.kind)}
-		{const stale = isSensorStale(sensor.timestamp)}
+		{const stale = $derived(isSensorStale(sensor.timestamp, undefined, now))}
 		<div
 			data-testid="sensor-reading"
 			class="card bg-surface-100-900 reveal flex flex-col gap-1 p-3 {stale ? 'opacity-60' : ''}"

--- a/web/src/routes/admin/settings/components/SensorsCard.svelte
+++ b/web/src/routes/admin/settings/components/SensorsCard.svelte
@@ -72,7 +72,7 @@
 			<p class="text-surface-500-400 py-2 text-sm">No sensors yet.</p>
 		{/if}
 		{#each sensors ?? [] as sensor (sensor.id)}
-			{const sensorError = errors?.[sensor.id]}
+			{const sensorError = $derived(errors?.[sensor.id])}
 			<div
 				data-testid="sensor-row-{sensor.id}"
 				class="rounded-lg border px-3 py-2 {sensorError


### PR DESCRIPTION
<!-- The PR title becomes the squash commit, so write it as a Conventional Commit. -->

## Summary

Fixes two sensor values that stayed stuck until a reload: the staleness dimming (SensorReadings) and the per-sensor error (SensorsCard) used non-reactive `{const}` declaration tags (same as the wifi connection badge issue fixed in PR #6 ).

## Checklist

- [x] Title follows Conventional Commits (`type(scope): summary`).
- [x] `make lint` and `make test` pass locally.
- [x] Tests cover the change, or it needs none (for example, docs only).
- [ ] `make generate` run if the API changed.
- [x] No breaking change in a minor or patch release (see CONTRIBUTING).
