### PR TITLE
fix(deploy): fix vcgencmd browser systemd service

### DIFF
--- a/deploy/systemd/kiosk-browser-drm.service
+++ b/deploy/systemd/kiosk-browser-drm.service
@@ -24,5 +24,6 @@ RestartSec=10
 
 SupplementaryGroups=video render
 
+# WantedBy the backend so its start pulls the browser back (BindsTo/PartOf only propagate stop).
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target kiosk-backend.service

--- a/deploy/systemd/kiosk-browser.service
+++ b/deploy/systemd/kiosk-browser.service
@@ -30,5 +30,6 @@ RestartSec=10
 
 SupplementaryGroups=video render
 
+# WantedBy the backend so its start pulls the browser back (BindsTo/PartOf only propagate stop).
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target kiosk-backend.service


### PR DESCRIPTION
<!-- The PR title becomes the squash commit, so write it as a Conventional Commit. -->

## Summary

On the vcgencmd/DRM path, a `systemctl stop` then `start` of the backend left the kiosk browser dead: `BindsTo`/`PartOf` propagate stop and restart but not start, and the backend's `Wants=` named only the Wayland browser. 

Both browser units now declare `WantedBy=…kiosk-backend.service`, so enabling them makes a backend start pull the browser back up.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): summary`).
- [ ] `make lint` and `make test` pass locally.
- [ ] Tests cover the change, or it needs none (for example, docs only).
- [ ] `make generate` run if the API changed.
- [x] No breaking change in a minor or patch release (see CONTRIBUTING).
