### PR TITLE
refactor(admin): minor ui tweaks

### DIFF
--- a/web/e2e/settings.spec.ts
+++ b/web/e2e/settings.spec.ts
@@ -120,6 +120,10 @@ test.describe('settings', () => {
 		await settings.save.click();
 		await expect(settings.saveBar).toBeHidden();
 
+		await expect(settings.restartDialog).toBeVisible();
+		await settings.restartCancel.click();
+		await expect(settings.restartDialog).toBeHidden();
+
 		await expect(settings.restartNow).toBeVisible();
 		await settings.restartNow.click();
 		await expect(settings.restartDialog).toBeVisible();

--- a/web/src/lib/InfoTip.svelte
+++ b/web/src/lib/InfoTip.svelte
@@ -1,19 +1,25 @@
 <script lang="ts">
+	import { Popover, Portal } from '@skeletonlabs/skeleton-svelte';
 	import { InfoIcon } from '@lucide/svelte';
 
 	let { text }: { text: string } = $props();
 </script>
 
-<!-- CSS-only: shows on mouse hover and on focus. Tapping the button focuses it,
-     so it works on touch too, no JS state to desync, no transition to stick. -->
-<span class="group relative inline-flex align-middle">
-	<button type="button" class="text-surface-500 hover:text-surface-700-300" aria-label={text}>
-		<InfoIcon class="size-3.5" />
-	</button>
-	<span
-		role="tooltip"
-		class="bg-surface-950-50 text-surface-50-950 pointer-events-none absolute bottom-full left-1/2 z-50 mb-1.5 hidden w-max max-w-56 -translate-x-1/2 rounded px-2.5 py-1.5 text-xs shadow-lg group-focus-within:block group-hover:block"
+<Popover autoFocus={false} positioning={{ placement: 'top', gutter: 6 }}>
+	<Popover.Trigger
+		type="button"
+		class="text-surface-500 hover:text-surface-700-300 inline-flex align-middle"
+		aria-label={text}
 	>
-		{text}
-	</span>
-</span>
+		<InfoIcon class="size-3.5" />
+	</Popover.Trigger>
+	<Portal>
+		<Popover.Positioner>
+			<Popover.Content
+				class="bg-surface-950-50 text-surface-50-950 pointer-events-none z-50 max-w-56 rounded px-2.5 py-1.5 text-xs shadow-lg"
+			>
+				{text}
+			</Popover.Content>
+		</Popover.Positioner>
+	</Portal>
+</Popover>

--- a/web/src/routes/admin/settings/+page.svelte
+++ b/web/src/routes/admin/settings/+page.svelte
@@ -150,7 +150,10 @@
 		saveError = null;
 		const result = await saveConfig(draft);
 		saving = false;
-		if (result.ok) return;
+		if (result.ok) {
+			if (result.restart_pending) showRestartDialog = true;
+			return;
+		}
 		saveError = result.detail;
 		// Open the section the backend named.
 		const section = sectionFromDetail(result.detail);

--- a/web/src/routes/admin/settings/components/RestartConfirmDialog.svelte
+++ b/web/src/routes/admin/settings/components/RestartConfirmDialog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { Dialog, Portal } from '@skeletonlabs/skeleton-svelte';
 	import { restartFrame } from '$lib/config';
 
 	let {
@@ -45,39 +46,54 @@
 	});
 </script>
 
-<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-	{#if restarting}
-		<div class="card bg-surface-50-950 w-full max-w-sm space-y-4 p-6 text-center shadow-xl">
-			<p class="text-lg font-semibold">Restarting…</p>
-			<p class="text-surface-500-400 text-sm">Waiting for the frame to come back online.</p>
-		</div>
-	{:else}
-		<div
-			data-testid="restart-dialog"
-			class="card bg-surface-50-950 w-full max-w-sm space-y-4 p-6 shadow-xl"
-		>
-			<h3 class="h4">Restart frame?</h3>
-			<p class="text-surface-600-300 text-sm">
-				The frame will restart and be unreachable for a few seconds. Unsaved changes will be lost.
-			</p>
-			<div class="flex justify-end gap-2">
-				<button
-					type="button"
-					class="btn preset-tonal-surface"
-					data-testid="restart-cancel"
-					onclick={oncancel}
+<Dialog
+	open
+	onOpenChange={(d: { open: boolean }) => {
+		if (!d.open && !restarting) oncancel();
+	}}
+>
+	<Portal>
+		<Dialog.Backdrop class="fixed inset-0 z-50 bg-black/50" />
+		<Dialog.Positioner class="fixed inset-0 z-50 flex items-center justify-center p-4">
+			{#if restarting}
+				<Dialog.Content
+					class="card bg-surface-100-900 w-full max-w-sm space-y-4 p-6 text-center shadow-xl"
 				>
-					Cancel
-				</button>
-				<button
-					type="button"
-					class="btn preset-tonal-error"
-					data-testid="restart-confirm"
-					onclick={handleConfirm}
+					<Dialog.Title class="text-lg font-semibold">Restarting…</Dialog.Title>
+					<Dialog.Description class="text-surface-500-400 text-sm">
+						Waiting for the frame to come back online.
+					</Dialog.Description>
+				</Dialog.Content>
+			{:else}
+				<Dialog.Content
+					data-testid="restart-dialog"
+					class="card bg-surface-100-900 w-full max-w-sm space-y-4 p-6 shadow-xl"
 				>
-					Restart
-				</button>
-			</div>
-		</div>
-	{/if}
-</div>
+					<Dialog.Title class="h4">Restart frame?</Dialog.Title>
+					<Dialog.Description class="text-surface-600-300 text-sm">
+						The frame will restart and be unreachable for a few seconds. Unsaved changes will be
+						lost.
+					</Dialog.Description>
+					<div class="flex justify-end gap-2">
+						<button
+							type="button"
+							class="btn preset-tonal-surface"
+							data-testid="restart-cancel"
+							onclick={oncancel}
+						>
+							Cancel
+						</button>
+						<button
+							type="button"
+							class="btn preset-tonal-error"
+							data-testid="restart-confirm"
+							onclick={handleConfirm}
+						>
+							Restart
+						</button>
+					</div>
+				</Dialog.Content>
+			{/if}
+		</Dialog.Positioner>
+	</Portal>
+</Dialog>

--- a/web/src/routes/admin/settings/components/SensorDialog.svelte
+++ b/web/src/routes/admin/settings/components/SensorDialog.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { SensorDto, ConfigMetaBody } from '$lib/api/types.gen';
 	import { untrack } from 'svelte';
+	import { Dialog, Portal } from '@skeletonlabs/skeleton-svelte';
 	import { RadioIcon } from '@lucide/svelte';
 	import Field from './Field.svelte';
 	import BleFields from './BleFields.svelte';
@@ -94,83 +95,91 @@
 	}
 </script>
 
-<svelte:window onkeydown={(e) => e.key === 'Escape' && onCancel()} />
-
-<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
-	<form
-		class="card bg-surface-50-950 max-h-[90vh] w-full max-w-lg space-y-5 overflow-y-auto p-6 shadow-xl"
-		onsubmit={handleSubmit}
-	>
-		<h3 class="h4 flex items-center gap-2">
-			<RadioIcon class="text-primary-500 size-5" />
-			{isNew ? 'Add sensor' : 'Edit sensor'}
-		</h3>
-
-		<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-			<Field label="ID" help="Unique name for this sensor." error={idConflict}>
-				<input
-					class="input"
-					type="text"
-					bind:value={draft.id}
-					placeholder="sensor1"
-					required
-					data-testid="sensor-dialog-id"
-				/>
-			</Field>
-			<Field label="Role" help="Groups readings on the frame, e.g. inside or outside.">
-				<input
-					class="input"
-					type="text"
-					bind:value={draft.role}
-					placeholder="inside"
-					required
-					data-testid="sensor-dialog-role"
-				/>
-			</Field>
-		</div>
-
-		<Field label="Type" help="Bluetooth (BLE), an MQTT topic, or a built-in mock source.">
-			<select
-				class="select"
-				value={draft.type}
-				onchange={(e) => (draft.type = toSensorType(e.currentTarget.value) ?? draft.type)}
+<Dialog
+	open
+	onOpenChange={(d: { open: boolean }) => {
+		if (!d.open) onCancel();
+	}}
+>
+	<Portal>
+		<Dialog.Backdrop class="fixed inset-0 z-50 bg-black/50" />
+		<Dialog.Positioner class="fixed inset-0 z-50 flex items-center justify-center p-4">
+			<Dialog.Content
+				class="card bg-surface-100-900 max-h-[90vh] w-full max-w-lg overflow-y-auto p-6 shadow-xl"
 			>
-				{#each meta.sensor_types ?? [] as t (t)}
-					<option value={t}>{TYPE_LABELS[t] ?? t}</option>
-				{/each}
-			</select>
-		</Field>
+				<Dialog.Title class="h4 flex items-center gap-2">
+					<RadioIcon class="text-primary-500 size-5" />
+					{isNew ? 'Add sensor' : 'Edit sensor'}
+				</Dialog.Title>
+				<form class="mt-5 space-y-5" onsubmit={handleSubmit}>
+					<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+						<Field label="ID" help="Unique name for this sensor." error={idConflict}>
+							<input
+								class="input"
+								type="text"
+								bind:value={draft.id}
+								placeholder="sensor1"
+								required
+								data-testid="sensor-dialog-id"
+							/>
+						</Field>
+						<Field label="Role" help="Groups readings on the frame, e.g. inside or outside.">
+							<input
+								class="input"
+								type="text"
+								bind:value={draft.role}
+								placeholder="inside"
+								required
+								data-testid="sensor-dialog-role"
+							/>
+						</Field>
+					</div>
 
-		{#if draft.type === 'ble'}
-			<BleFields bind:draft {meta} />
-		{:else if draft.type === 'mqtt-subscriber'}
-			<MqttSubscriberFields bind:draft {meta} />
-		{:else if draft.type === 'mock'}
-			<MockFields bind:draft {meta} />
-		{/if}
+					<Field label="Type" help="Bluetooth (BLE), an MQTT topic, or a built-in mock source.">
+						<select
+							class="select"
+							value={draft.type}
+							onchange={(e) => (draft.type = toSensorType(e.currentTarget.value) ?? draft.type)}
+						>
+							{#each meta.sensor_types ?? [] as t (t)}
+								<option value={t}>{TYPE_LABELS[t] ?? t}</option>
+							{/each}
+						</select>
+					</Field>
 
-		{#if typeError}
-			<p class="text-error-500 text-sm">{typeError}</p>
-		{/if}
-		{#if roleKindConflict}
-			<p class="text-error-500 text-sm">{roleKindConflict}</p>
-		{/if}
+					{#if draft.type === 'ble'}
+						<BleFields bind:draft {meta} />
+					{:else if draft.type === 'mqtt-subscriber'}
+						<MqttSubscriberFields bind:draft {meta} />
+					{:else if draft.type === 'mock'}
+						<MockFields bind:draft {meta} />
+					{/if}
 
-		<div class="flex justify-end gap-2 pt-2">
-			<button
-				type="button"
-				class="btn preset-tonal-surface"
-				onclick={onCancel}
-				data-testid="sensor-dialog-cancel">Cancel</button
-			>
-			<button
-				type="submit"
-				class="btn preset-tonal-primary"
-				disabled={!canSave}
-				data-testid="sensor-dialog-save"
-			>
-				{isNew ? 'Add' : 'Save'}
-			</button>
-		</div>
-	</form>
-</div>
+					{#if typeError}
+						<p class="text-error-500 text-sm">{typeError}</p>
+					{/if}
+					{#if roleKindConflict}
+						<p class="text-error-500 text-sm">{roleKindConflict}</p>
+					{/if}
+
+					<div class="flex justify-end gap-2 pt-2">
+						<button
+							type="button"
+							class="btn preset-tonal-surface"
+							onclick={onCancel}
+							data-testid="sensor-dialog-cancel">Cancel</button
+						>
+						<button
+							type="submit"
+							class="btn preset-tonal-primary"
+							disabled={!canSave}
+							data-testid="sensor-dialog-save"
+						>
+							{isNew ? 'Add' : 'Save'}
+						</button>
+					</div>
+				</form>
+			</Dialog.Content>
+		</Dialog.Positioner>
+	</Portal>
+</Dialog>


### PR DESCRIPTION
<!-- The PR title becomes the squash commit, so write it as a Conventional Commit. -->

## Summary

- Rebuild InfoTip on Skeleton's Popover so the tooltip is no longer clipped inside dialogs or at screen edges; opens on click/tap.
- Migrate SensorDialog and RestartConfirmDialog to Skeleton Dialog.
- After a successful restart-required save, open the restart dialog automatically.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): summary`).
- [x] `make lint` and `make test` pass locally.
- [x] Tests cover the change, or it needs none (for example, docs only).
- [ ] `make generate` run if the API changed.
- [x] No breaking change in a minor or patch release (see CONTRIBUTING).
