### PR TITLE
docs: update documentation site url

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/MateEke/picture-frame/discussions
     about: For usage questions and open-ended ideas, please start a discussion.
   - name: Documentation
-    url: https://picture-frame-2kf.pages.dev/
+    url: https://pictureframe.ekemate.hu/
     about: Setup, configuration, and the user manual.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Your photos beside the time, the weather, and the real temperature in your rooms. Motion-aware,
 private, and plugged into Home Assistant.
 
-[![Documentation](https://img.shields.io/badge/Documentation-4F46E5?style=for-the-badge)](https://picture-frame-2kf.pages.dev)
+[![Documentation](https://img.shields.io/badge/Documentation-4F46E5?style=for-the-badge)](https://pictureframe.ekemate.hu)
 &nbsp;
 [![Install](https://img.shields.io/badge/Install-334155?style=for-the-badge)](#install)
 &nbsp;
@@ -49,7 +49,7 @@ W driving an HD screen, and written in Go and Svelte.
 
 ## Documentation
 
-The full documentation lives at **<https://picture-frame-2kf.pages.dev>**. It covers installation,
+The full documentation lives at **<https://pictureframe.ekemate.hu>**. It covers installation,
 a guided tour of the admin interface, every configuration option, and the engineering notes behind
 the project.
 
@@ -61,7 +61,7 @@ On a fresh Raspberry Pi OS Trixie Lite, reachable over SSH:
 curl -fsSL https://github.com/MateEke/picture-frame/releases/latest/download/install.sh | sudo bash
 ```
 
-See the [Install guide](https://picture-frame-2kf.pages.dev/getting-started/install/) for the
+See the [Install guide](https://pictureframe.ekemate.hu/getting-started/install/) for the
 requirements, options, and first setup.
 
 ## Development

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,6 +36,6 @@ that. A few behaviors are intentional, documented design rather than vulnerabili
 - **First-come admin password.** Until an admin password is set, anyone who can reach the
   interface can set it. Set one promptly; the installer prompts for it.
 
-These are covered in the [Security guide](https://picture-frame-2kf.pages.dev/manual/security/).
+These are covered in the [Security guide](https://pictureframe.ekemate.hu/manual/security/).
 Reports that only restate them are out of scope. In scope: bypassing a configured password, the
 update signature check, or the Wi-Fi credential handling.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,7 +1,7 @@
 # Deployment internals (Raspberry Pi)
 
 End-user installation, requirements, options, and first setup live in the documentation:
-<https://picture-frame-2kf.pages.dev/getting-started/install/>. The installer (`install.sh`) handles all
+<https://pictureframe.ekemate.hu/getting-started/install/>. The installer (`install.sh`) handles all
 of it, and `install.sh --help` lists every flag.
 
 This file covers the system-level details behind that install: how the kiosk stack is wired, and the

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 The documentation site for Picture Frame, built with [Astro](https://astro.build) and
 [Starlight](https://starlight.astro.build). It deploys to Cloudflare Pages at
-<https://picture-frame-2kf.pages.dev>. `.github/workflows/docs.yml` builds the site and validates
+<https://pictureframe.ekemate.hu>. `.github/workflows/docs.yml` builds the site and validates
 its links on every change; Cloudflare builds and deploys the site itself.
 
 This project is self-contained: it has its own `package.json` and does not share tooling

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -7,10 +7,10 @@ import rehypeExternalLinks from 'rehype-external-links';
 import starlightLinksValidator from 'starlight-links-validator';
 
 // GitHub owner/repo (edit + social links) and the deployed docs URL.
-// SITE_URL is the Cloudflare Pages URL; update it if the docs move to a custom domain.
+// SITE_URL is the custom domain; canonical URLs and the sitemap are built from it.
 const GITHUB_OWNER = 'MateEke';
 const REPO_NAME = 'picture-frame';
-const SITE_URL = 'https://picture-frame-2kf.pages.dev';
+const SITE_URL = 'https://pictureframe.ekemate.hu';
 
 // https://astro.build/config
 export default defineConfig({

--- a/web/e2e/settings.spec.ts
+++ b/web/e2e/settings.spec.ts
@@ -37,7 +37,7 @@ test.describe('settings', () => {
 	});
 
 	test('links to the manual', async ({ settings }) => {
-		await expect(settings.docs).toHaveAttribute('href', /pages\.dev\/manual/);
+		await expect(settings.docs).toHaveAttribute('href', /pictureframe\.ekemate\.hu\/manual/);
 	});
 
 	test('blocks save on invalid input', async ({ settings }) => {

--- a/web/e2e/updates.spec.ts
+++ b/web/e2e/updates.spec.ts
@@ -14,7 +14,7 @@ test.describe('updates', () => {
 			await expect(dashboard.aboutVersion).toBeVisible();
 			await expect(dashboard.aboutCheck).toBeVisible();
 			await expect(dashboard.aboutGithub).toHaveAttribute('href', /github\.com/);
-			await expect(dashboard.aboutDocs).toHaveAttribute('href', /pages\.dev/);
+			await expect(dashboard.aboutDocs).toHaveAttribute('href', /pictureframe\.ekemate\.hu/);
 		});
 
 		test('installs from the dashboard, then the panel clears', async ({ dashboard }) => {

--- a/web/src/lib/links.ts
+++ b/web/src/lib/links.ts
@@ -1,4 +1,4 @@
 // Canonical project URLs, defined once so the UI links stay in sync.
 export const REPO_URL = 'https://github.com/MateEke/picture-frame';
-export const DOCS_URL = 'https://picture-frame-2kf.pages.dev';
+export const DOCS_URL = 'https://pictureframe.ekemate.hu';
 export const MANUAL_URL = `${DOCS_URL}/manual/dashboard/`;


### PR DESCRIPTION
<!-- The PR title becomes the squash commit, so write it as a Conventional Commit. -->

## Summary

Replaces documentation links with [pictureframe.ekemate.hu](https://pictureframe.ekemate.hu)

## Checklist

- [x] Title follows Conventional Commits (`type(scope): summary`).
- [x] `make lint` and `make test` pass locally.
- [x] Tests cover the change, or it needs none (for example, docs only).
- [ ] `make generate` run if the API changed.
- [x] No breaking change in a minor or patch release (see CONTRIBUTING).
