### PR TITLE
refactor(immich): move album sync to timeline api

### DIFF
--- a/cmd/picture-frame/wiring.go
+++ b/cmd/picture-frame/wiring.go
@@ -111,6 +111,7 @@ func startLibrarySyncer(ctx context.Context, log *slog.Logger, cfg *config.Confi
 	client, err := immich.New(immich.Config{
 		ShareURL: cfg.Library.Immich.ShareURL,
 		Password: cfg.Library.Immich.SharePassword,
+		Logger:   log,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/library/adapter/immich/immich.go
+++ b/internal/library/adapter/immich/immich.go
@@ -7,7 +7,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -21,10 +23,22 @@ type httpError struct{ Status int }
 
 func (e *httpError) Error() string { return fmt.Sprintf("status %d", e.Status) }
 
+const noThumbhashToken = "0000000000000000"
+
+// thumbhashToken derives a fixed-length, filesystem-safe change token. thumbhash
+// tracks rendered content, so the token moves on edits and is stable otherwise.
+func thumbhashToken(thumbhash string) string {
+	if thumbhash == "" {
+		return noThumbhashToken
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(thumbhash))
+	return fmt.Sprintf("%016x", h.Sum64())
+}
+
 const (
 	defaultTimeout  = 30 * time.Second
 	thumbnailSize   = "preview"
-	imageTypeImage  = "IMAGE"
 	sharePathPrefix = "/share/"
 	// sharedLinkCookieName carries the password-exchange token on Immich >= 2.6.0.
 	sharedLinkCookieName = "immich_shared_link_token"
@@ -40,10 +54,15 @@ type Client struct {
 	key      string
 	password string
 	http     *http.Client
+	log      *slog.Logger
 
 	albumID        string // cached after first List
 	token          string // immich_shared_link_token cookie value; set by login
 	legacyPassword bool   // pre-2.6 server: send the password as a query parameter
+
+	cached    []library.Asset // last enumeration; returned when the album ETag is unchanged
+	albumETag string          // album response ETag; gates re-enumeration
+	loaded    bool            // an enumeration has succeeded at least once
 }
 
 // Config configures the client.
@@ -51,6 +70,7 @@ type Config struct {
 	ShareURL string // full share URL, e.g. https://host/share/<key>
 	Password string
 	HTTP     *http.Client // optional override (defaults to a 30s-timeout client)
+	Logger   *slog.Logger // optional; defaults to a discard logger
 }
 
 // New parses cfg.ShareURL and returns a ready-to-use Client.
@@ -59,16 +79,18 @@ func New(cfg Config) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	c := &Client{base: base, key: key, password: cfg.Password, http: cfg.HTTP}
+	c := &Client{base: base, key: key, password: cfg.Password, http: cfg.HTTP, log: cfg.Logger}
 	if c.http == nil {
 		c.http = &http.Client{Timeout: defaultTimeout}
+	}
+	if c.log == nil {
+		c.log = slog.New(slog.DiscardHandler)
 	}
 	return c, nil
 }
 
-// List fetches the album manifest and returns image assets only. Retries once
-// on 404 (stale album ID) or 401 (stale token, e.g. the share password changed).
-// Pagination is not implemented; large albums may need it.
+// List returns the album's image assets. Retries once on 404 (stale album ID)
+// or 401 (stale token, e.g. the share password changed).
 func (c *Client) List(ctx context.Context) ([]library.Asset, error) {
 	out, err := c.listOnce(ctx)
 	if err == nil {
@@ -81,6 +103,7 @@ func (c *Client) List(ctx context.Context) ([]library.Asset, error) {
 	switch hErr.Status {
 	case http.StatusNotFound:
 		c.albumID = ""
+		c.albumETag = ""
 	case http.StatusUnauthorized:
 		c.token = ""
 	default:
@@ -135,24 +158,100 @@ func (c *Client) listOnce(ctx context.Context) ([]library.Asset, error) {
 	if err != nil {
 		return nil, err
 	}
-	var album struct {
-		Assets []struct {
-			ID        string    `json:"id"`
-			Type      string    `json:"type"`
-			UpdatedAt time.Time `json:"updatedAt"`
-		} `json:"assets"`
+	changed, etag, err := c.albumChanged(ctx, albumID)
+	if err != nil {
+		return nil, err
 	}
-	if err := c.getJSON(ctx, "/api/albums/"+albumID, &album); err != nil {
-		return nil, fmt.Errorf("immich: list album: %w", err)
+	if !changed {
+		c.log.Debug("immich: album unchanged, served from cache", "assets", len(c.cached))
+		return c.cached, nil
 	}
-	out := make([]library.Asset, 0, len(album.Assets))
-	for _, a := range album.Assets {
-		if a.Type != imageTypeImage || a.UpdatedAt.IsZero() {
+	assets, buckets, err := c.enumerate(ctx, albumID)
+	if err != nil {
+		return nil, err
+	}
+	c.cached, c.albumETag, c.loaded = assets, etag, true
+	c.log.Debug("immich: enumerated album", "assets", len(assets), "buckets", buckets)
+	return assets, nil
+}
+
+// albumChanged conditional-GETs the album: a 304 reuses the cache, a 200 means
+// re-enumerate. It returns the new ETag rather than storing it, so listOnce can
+// commit it only with a successful enumeration (else a failed enumeration would
+// leave a stale cache behind an advanced ETag).
+func (c *Client) albumChanged(ctx context.Context, albumID string) (changed bool, etag string, err error) {
+	forceFull := !c.loaded || c.albumETag == ""
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url("/api/albums/"+albumID, nil), nil)
+	if err != nil {
+		return false, "", err
+	}
+	c.addAuthCookie(req)
+	if !forceFull {
+		req.Header.Set("If-None-Match", c.albumETag)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return false, "", fmt.Errorf("immich: album gate: %w", err)
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusNotModified:
+		return false, "", nil
+	case http.StatusOK:
+		return true, resp.Header.Get("ETag"), nil
+	default:
+		return false, "", &httpError{Status: resp.StatusCode}
+	}
+}
+
+// enumerate lists the album's image assets via the timeline API (the only
+// key-authenticated listing after Immich v3 dropped AlbumResponseDto.assets) and
+// returns the number of buckets it fetched.
+func (c *Client) enumerate(ctx context.Context, albumID string) ([]library.Asset, int, error) {
+	var buckets []timelineBucketMeta
+	if err := c.getJSON(ctx, "/api/timeline/buckets", url.Values{"albumId": {albumID}}, &buckets); err != nil {
+		return nil, 0, fmt.Errorf("immich: list buckets: %w", err)
+	}
+	var out []library.Asset
+	for _, b := range buckets {
+		var bucket timelineBucket
+		q := url.Values{"albumId": {albumID}, "timeBucket": {b.TimeBucket}}
+		if err := c.getJSON(ctx, "/api/timeline/bucket", q, &bucket); err != nil {
+			return nil, 0, fmt.Errorf("immich: bucket %s: %w", b.TimeBucket, err)
+		}
+		out = appendImageAssets(out, bucket)
+	}
+	return out, len(buckets), nil
+}
+
+type timelineBucketMeta struct {
+	TimeBucket string `json:"timeBucket"`
+}
+
+// timelineBucket is the columnar (struct-of-arrays) shape Immich returns per bucket.
+type timelineBucket struct {
+	ID        []string `json:"id"`
+	IsImage   []bool   `json:"isImage"`
+	Thumbhash []string `json:"thumbhash"`
+}
+
+// appendImageAssets maps the columnar payload to image assets, tolerating short
+// or absent optional arrays.
+func appendImageAssets(out []library.Asset, b timelineBucket) []library.Asset {
+	for i, id := range b.ID {
+		if id == "" {
 			continue
 		}
-		out = append(out, library.Asset{ID: a.ID, UpdatedAt: a.UpdatedAt})
+		if i < len(b.IsImage) && !b.IsImage[i] {
+			continue
+		}
+		th := ""
+		if i < len(b.Thumbhash) {
+			th = b.Thumbhash[i]
+		}
+		out = append(out, library.Asset{ID: id, Version: thumbhashToken(th)})
 	}
-	return out, nil
+	return out
 }
 
 // Fetch returns the preview-sized thumbnail stream for assetID.
@@ -174,7 +273,7 @@ func (c *Client) resolveAlbumID(ctx context.Context) (string, error) {
 			ID string `json:"id"`
 		} `json:"album"`
 	}
-	if err := c.getJSON(ctx, "/api/shared-links/me", &share); err != nil {
+	if err := c.getJSON(ctx, "/api/shared-links/me", nil, &share); err != nil {
 		return "", fmt.Errorf("immich: resolve share: %w", err)
 	}
 	if share.Album.ID == "" {
@@ -184,8 +283,8 @@ func (c *Client) resolveAlbumID(ctx context.Context) (string, error) {
 	return c.albumID, nil
 }
 
-func (c *Client) getJSON(ctx context.Context, path string, dst any) error {
-	resp, err := c.do(ctx, c.url(path, nil))
+func (c *Client) getJSON(ctx context.Context, path string, extra url.Values, dst any) error {
+	resp, err := c.do(ctx, c.url(path, extra))
 	if err != nil {
 		return err
 	}
@@ -193,15 +292,20 @@ func (c *Client) getJSON(ctx context.Context, path string, dst any) error {
 	return json.NewDecoder(resp.Body).Decode(dst)
 }
 
+// addAuthCookie attaches the shared-link token via the Cookie header. Response
+// attributes (Secure/HttpOnly) don't apply to an outgoing cookie.
+func (c *Client) addAuthCookie(req *http.Request) {
+	if c.token != "" {
+		req.Header.Set("Cookie", sharedLinkCookieName+"="+c.token)
+	}
+}
+
 func (c *Client) do(ctx context.Context, u string) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return nil, err
 	}
-	if c.token != "" {
-		// Outgoing request cookie: Secure/HttpOnly/SameSite are response-only attributes.
-		req.AddCookie(&http.Cookie{Name: sharedLinkCookieName, Value: c.token}) //nolint:gosec
-	}
+	c.addAuthCookie(req)
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, err

--- a/internal/library/adapter/immich/immich_test.go
+++ b/internal/library/adapter/immich/immich_test.go
@@ -1,14 +1,17 @@
 package immich_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/MateEke/picture-frame/internal/library/adapter/immich"
 )
@@ -30,11 +33,18 @@ type recordedRequest struct {
 	cookie string // immich_shared_link_token value, if sent
 }
 
+type fakeAsset struct {
+	id        string
+	isImage   bool
+	thumbhash string
+}
+
 type fakeImmich struct {
 	mu       sync.Mutex
 	requests []recordedRequest
-	album    string
-	assets   string
+	album    string      // /shared-links/me response
+	assets   []fakeAsset // timeline contents
+	etag     string      // album ETag; "" disables conditional caching
 	preview  []byte
 	status   int
 	// loginStatus drives POST /api/shared-links/login: 0 mimics a pre-2.6 server
@@ -47,7 +57,7 @@ func newFakeImmich(t *testing.T) *fakeImmich {
 	t.Helper()
 	return &fakeImmich{
 		album:   `{"album":{"id":"` + testAlbumID + `"}}`,
-		assets:  `{"assets":[]}`,
+		etag:    `"etag-v1"`,
 		preview: []byte("PREVIEW-BYTES"),
 		status:  http.StatusOK,
 	}
@@ -74,18 +84,10 @@ func (f *fakeImmich) handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		f.record(r)
 		f.mu.Lock()
-		status, loginStatus, loginToken := f.status, f.loginStatus, f.loginToken
+		status, loginStatus, loginToken, etag := f.status, f.loginStatus, f.loginToken, f.etag
 		f.mu.Unlock()
 		if r.URL.Path == "/api/shared-links/login" {
-			switch loginStatus {
-			case 0:
-				http.NotFound(w, r)
-			case http.StatusOK, http.StatusCreated:
-				http.SetCookie(w, &http.Cookie{Name: "immich_shared_link_token", Value: loginToken, HttpOnly: true, Secure: true, SameSite: http.SameSiteLaxMode})
-				w.WriteHeader(loginStatus)
-			default:
-				http.Error(w, "denied", loginStatus)
-			}
+			f.serveLogin(w, r, loginStatus, loginToken)
 			return
 		}
 		if status != http.StatusOK {
@@ -94,11 +96,13 @@ func (f *fakeImmich) handler() http.Handler {
 		}
 		switch {
 		case r.URL.Path == "/api/shared-links/me":
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = io.WriteString(w, f.album)
+			writeJSON(w, f.album)
 		case r.URL.Path == "/api/albums/"+testAlbumID:
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = io.WriteString(w, f.assets)
+			serveGate(w, r, etag)
+		case r.URL.Path == "/api/timeline/buckets":
+			f.serveBuckets(w)
+		case r.URL.Path == "/api/timeline/bucket":
+			f.serveBucket(w)
 		case strings.HasPrefix(r.URL.Path, "/api/assets/") && strings.HasSuffix(r.URL.Path, "/thumbnail"):
 			w.Header().Set("Content-Type", "image/jpeg")
 			_, _ = w.Write(f.preview)
@@ -106,6 +110,63 @@ func (f *fakeImmich) handler() http.Handler {
 			http.NotFound(w, r)
 		}
 	})
+}
+
+func (f *fakeImmich) serveLogin(w http.ResponseWriter, r *http.Request, loginStatus int, loginToken string) {
+	switch loginStatus {
+	case 0:
+		http.NotFound(w, r)
+	case http.StatusOK, http.StatusCreated:
+		http.SetCookie(w, &http.Cookie{Name: "immich_shared_link_token", Value: loginToken, HttpOnly: true, Secure: true, SameSite: http.SameSiteLaxMode})
+		w.WriteHeader(loginStatus)
+	default:
+		http.Error(w, "denied", loginStatus)
+	}
+}
+
+func serveGate(w http.ResponseWriter, r *http.Request, etag string) {
+	if etag != "" {
+		if r.Header.Get("If-None-Match") == etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("ETag", etag)
+	}
+	writeJSON(w, `{"id":"`+testAlbumID+`"}`)
+}
+
+func (f *fakeImmich) serveBuckets(w http.ResponseWriter) {
+	f.mu.Lock()
+	n := len(f.assets)
+	f.mu.Unlock()
+	if n == 0 {
+		writeJSON(w, `[]`)
+		return
+	}
+	writeJSON(w, `[{"timeBucket":"2026-05-01","count":`+strconv.Itoa(n)+`}]`)
+}
+
+func (f *fakeImmich) serveBucket(w http.ResponseWriter) {
+	f.mu.Lock()
+	assets := append([]fakeAsset(nil), f.assets...)
+	f.mu.Unlock()
+	var cols struct {
+		ID        []string `json:"id"`
+		IsImage   []bool   `json:"isImage"`
+		Thumbhash []string `json:"thumbhash"`
+	}
+	for _, a := range assets {
+		cols.ID = append(cols.ID, a.id)
+		cols.IsImage = append(cols.IsImage, a.isImage)
+		cols.Thumbhash = append(cols.Thumbhash, a.thumbhash)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(cols)
+}
+
+func writeJSON(w http.ResponseWriter, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = io.WriteString(w, body)
 }
 
 func newClient(t *testing.T, srv *httptest.Server, password string) *immich.Client {
@@ -169,11 +230,11 @@ func TestParseShareURLIgnoresQueryAndFragment(t *testing.T) {
 
 func TestListReturnsImageAssetsOnly(t *testing.T) {
 	fake := newFakeImmich(t)
-	fake.assets = `{"assets":[
-		{"id":"` + assetA + `","type":"IMAGE","updatedAt":"2026-04-20T08:00:11Z"},
-		{"id":"video","type":"VIDEO","updatedAt":"2026-04-20T08:00:11Z"},
-		{"id":"` + assetB + `","type":"IMAGE","updatedAt":"2026-04-21T08:00:11Z"}
-	]}`
+	fake.assets = []fakeAsset{
+		{id: assetA, isImage: true, thumbhash: "ha"},
+		{id: "video", isImage: false, thumbhash: "hv"},
+		{id: assetB, isImage: true, thumbhash: "hb"},
+	}
 	srv := httptest.NewServer(fake.handler())
 	defer srv.Close()
 	c := newClient(t, srv, "")
@@ -183,14 +244,91 @@ func TestListReturnsImageAssetsOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(got) != 2 {
-		t.Fatalf("got %d assets, want 2", len(got))
+		t.Fatalf("got %d assets, want 2 (video filtered)", len(got))
 	}
 	if got[0].ID != assetA || got[1].ID != assetB {
 		t.Errorf("ids: %v", got)
 	}
-	wantTime := time.Date(2026, 4, 20, 8, 0, 11, 0, time.UTC)
-	if !got[0].UpdatedAt.Equal(wantTime) {
-		t.Errorf("updatedAt: got %v, want %v", got[0].UpdatedAt, wantTime)
+	for _, a := range got {
+		if len(a.Version) != 16 {
+			t.Errorf("version %q is not 16 hex chars", a.Version)
+		}
+	}
+	if got[0].Version == got[1].Version {
+		t.Error("distinct thumbhashes should yield distinct tokens")
+	}
+}
+
+// A missing thumbhash (not yet generated) maps to the sentinel token.
+func TestListTokenizesThumbhash(t *testing.T) {
+	fake := newFakeImmich(t)
+	fake.assets = []fakeAsset{
+		{id: assetA, isImage: true, thumbhash: ""},
+		{id: assetB, isImage: true, thumbhash: "hb"},
+	}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+	c := newClient(t, srv, "")
+
+	got, err := c.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got[0].Version != "0000000000000000" {
+		t.Errorf("empty thumbhash token = %q, want sentinel", got[0].Version)
+	}
+	if got[1].Version == "0000000000000000" {
+		t.Error("non-empty thumbhash should not map to the sentinel")
+	}
+}
+
+// The adapter logs whether a tick re-enumerated or was served from the 304 cache.
+func TestListLogsCacheVsEnumerate(t *testing.T) {
+	fake := newFakeImmich(t)
+	fake.assets = []fakeAsset{{id: assetA, isImage: true, thumbhash: "ha"}}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+	var buf bytes.Buffer
+	c, err := immich.New(immich.Config{
+		ShareURL: srv.URL + "/share/" + testKey,
+		HTTP:     srv.Client(),
+		Logger:   slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range 2 {
+		if _, err := c.List(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if out := buf.String(); !strings.Contains(out, "enumerated album") || !strings.Contains(out, "served from cache") {
+		t.Errorf("missing enumerate/cache log lines:\n%s", out)
+	}
+}
+
+// A second List with an unchanged album ETag is served from cache: no second
+// timeline enumeration.
+func TestListReusesCacheOn304(t *testing.T) {
+	fake := newFakeImmich(t)
+	fake.assets = []fakeAsset{{id: assetA, isImage: true, thumbhash: "ha"}}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+	c := newClient(t, srv, "")
+
+	for range 2 {
+		if _, err := c.List(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	buckets := 0
+	for _, r := range fake.requests {
+		if r.path == "/api/timeline/bucket" {
+			buckets++
+		}
+	}
+	if buckets != 1 {
+		t.Errorf("timeline/bucket fetched %d times, want 1 (second List served from 304)", buckets)
 	}
 }
 
@@ -223,7 +361,7 @@ func TestLegacyServerFallsBackToPasswordQuery(t *testing.T) {
 		t.Errorf("login probed %d times, want 1", logins)
 	}
 	if others < 2 {
-		t.Fatalf("expected at least 2 data requests (share-link + album), got %d", others)
+		t.Fatalf("expected at least 2 data requests, got %d", others)
 	}
 }
 
@@ -384,7 +522,6 @@ func TestFetchReturnsPreviewBody(t *testing.T) {
 	}
 	if thumbReq == nil {
 		t.Fatal("no thumbnail request recorded")
-		return
 	}
 	if thumbReq.size != "preview" {
 		t.Errorf("size=%q, want preview", thumbReq.size)
@@ -403,41 +540,25 @@ func TestFetchPropagatesHTTPError(t *testing.T) {
 	}
 }
 
-func TestListSkipsAssetsWithZeroUpdatedAt(t *testing.T) {
-	fake := newFakeImmich(t)
-	fake.assets = `{"assets":[
-		{"id":"` + assetA + `","type":"IMAGE","updatedAt":"2026-04-20T08:00:11Z"},
-		{"id":"zero","type":"IMAGE","updatedAt":"0001-01-01T00:00:00Z"}
-	]}`
-	srv := httptest.NewServer(fake.handler())
-	defer srv.Close()
-	c := newClient(t, srv, "")
-
-	got, err := c.List(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 1 || got[0].ID != assetA {
-		t.Errorf("zero-updatedAt asset should be skipped: %+v", got)
-	}
-}
-
 func TestListInvalidatesAlbumIDOn404(t *testing.T) {
 	fake := newFakeImmich(t)
-	var albumCalls int
+	var gateCalls int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/api/shared-links/me":
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = io.WriteString(w, fake.album)
-		case strings.HasPrefix(r.URL.Path, "/api/albums/"):
-			albumCalls++
-			if albumCalls == 1 {
+		switch r.URL.Path {
+		case "/api/shared-links/me":
+			writeJSON(w, fake.album)
+		case "/api/albums/" + testAlbumID:
+			gateCalls++
+			if gateCalls == 1 {
 				http.Error(w, "gone", http.StatusNotFound)
 				return
 			}
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = io.WriteString(w, fake.assets)
+			w.Header().Set("ETag", `"e"`)
+			writeJSON(w, `{}`)
+		case "/api/timeline/buckets":
+			writeJSON(w, `[{"timeBucket":"2026-05-01","count":1}]`)
+		case "/api/timeline/bucket":
+			writeJSON(w, `{"id":["`+assetA+`"],"isImage":[true],"thumbhash":["h"]}`)
 		default:
 			http.NotFound(w, r)
 		}
@@ -445,12 +566,12 @@ func TestListInvalidatesAlbumIDOn404(t *testing.T) {
 	defer srv.Close()
 	c := newClient(t, srv, "")
 
-	// First album call 404s; the retry succeeds after re-resolving via /me.
+	// First gate call 404s; the retry succeeds after re-resolving via /me.
 	if _, err := c.List(context.Background()); err != nil {
 		t.Fatalf("expected retry success, got %v", err)
 	}
-	if albumCalls != 2 {
-		t.Errorf("expected 2 album calls (first 404 → re-resolve → retry), got %d", albumCalls)
+	if gateCalls != 2 {
+		t.Errorf("expected 2 gate calls (404 → re-resolve → retry), got %d", gateCalls)
 	}
 }
 

--- a/internal/library/adapter/immich/token_test.go
+++ b/internal/library/adapter/immich/token_test.go
@@ -1,0 +1,19 @@
+package immich
+
+import "testing"
+
+func TestThumbhashToken(t *testing.T) {
+	if empty := thumbhashToken(""); empty != "0000000000000000" {
+		t.Errorf("empty thumbhash token = %q, want 16 zeros", empty)
+	}
+	a := thumbhashToken("mQgOBQRoiIB3iHeIiIiYaF6PeAh3")
+	if len(a) != 16 {
+		t.Errorf("token len = %d, want 16", len(a))
+	}
+	if a == thumbhashToken("differenthashvalue==") {
+		t.Error("distinct thumbhashes produced the same token")
+	}
+	if a != thumbhashToken("mQgOBQRoiIB3iHeIiIiYaF6PeAh3") {
+		t.Error("token not stable for the same thumbhash")
+	}
+}

--- a/internal/library/reconcile_internal_test.go
+++ b/internal/library/reconcile_internal_test.go
@@ -1,0 +1,15 @@
+package library
+
+import "testing"
+
+func TestStaleAgainstVersionMismatch(t *testing.T) {
+	const id = "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa"
+	local := localSet{{name: id + "-1111.jpg", id: id, version: "1111"}}
+
+	if stale := local.staleAgainst([]Asset{{ID: id, Version: "deadbeefdeadbeef"}}); len(stale) != 1 {
+		t.Fatalf("stale = %d, want 1 (token changed)", len(stale))
+	}
+	if stale := local.staleAgainst([]Asset{{ID: id, Version: "1111"}}); len(stale) != 0 {
+		t.Fatalf("stale = %d, want 0 (token unchanged)", len(stale))
+	}
+}

--- a/internal/library/remote.go
+++ b/internal/library/remote.go
@@ -3,13 +3,12 @@ package library
 import (
 	"context"
 	"io"
-	"time"
 )
 
 // Asset is one image in a RemoteAlbum.
 type Asset struct {
-	ID        string    // stable identity; used as the filename stem
-	UpdatedAt time.Time // changes when the asset is edited remotely
+	ID      string // stable identity; used as the filename stem
+	Version string // opaque change token; a new value means re-download
 }
 
 // RemoteAlbum is a read-only view of an album in a remote photo service.

--- a/internal/library/syncer.go
+++ b/internal/library/syncer.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"os"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -17,8 +16,8 @@ import (
 )
 
 // Syncer reconciles a RemoteAlbum with a local directory and Library on a tick.
-// Files are named "<asset-id>-<updatedAt-unix>.jpg" so an edit upstream becomes
-// a new local file (old version deleted, new version downloaded).
+// Files are named "<asset-id>-<version>.jpg" so an edit upstream (new version)
+// becomes a new local file: old version deleted, new version downloaded.
 type Syncer struct {
 	log      *slog.Logger
 	remote   RemoteAlbum
@@ -173,9 +172,9 @@ func (s *Syncer) syncOnce(ctx context.Context) {
 
 // localFile is the parsed form of a synced filename.
 type localFile struct {
-	name      string
-	id        string
-	updatedAt int64
+	name    string
+	id      string
+	version string
 }
 
 type localSet []localFile
@@ -189,15 +188,15 @@ func (ls localSet) byID() map[string]localFile {
 }
 
 // staleAgainst returns local files whose ID is gone from remote or whose
-// updatedAt differs from the remote version.
+// version differs from the remote one.
 func (ls localSet) staleAgainst(remote []Asset) []localFile {
-	want := make(map[string]int64, len(remote))
+	want := make(map[string]string, len(remote))
 	for _, a := range remote {
-		want[a.ID] = a.UpdatedAt.Unix()
+		want[a.ID] = a.Version
 	}
 	var out []localFile
 	for _, f := range ls {
-		if t, ok := want[f.id]; !ok || t != f.updatedAt {
+		if v, ok := want[f.id]; !ok || v != f.version {
 			out = append(out, f)
 		}
 	}
@@ -210,14 +209,14 @@ func (ls localSet) missingFrom(remote []Asset) []Asset {
 	have := ls.byID()
 	var out []Asset
 	for _, a := range remote {
-		if f, ok := have[a.ID]; !ok || f.updatedAt != a.UpdatedAt.Unix() {
+		if f, ok := have[a.ID]; !ok || f.version != a.Version {
 			out = append(out, a)
 		}
 	}
 	return out
 }
 
-var syncedNameRe = regexp.MustCompile(`^([0-9a-f-]{36})-(\d+)\.jpg$`)
+var syncedNameRe = regexp.MustCompile(`^([0-9a-f-]{36})-([0-9a-f]+)\.jpg$`)
 
 func (s *Syncer) scanLocal() (localSet, error) {
 	d, err := s.root.OpenFile(".", os.O_RDONLY, 0)
@@ -238,11 +237,7 @@ func (s *Syncer) scanLocal() (localSet, error) {
 		if match == nil {
 			continue
 		}
-		updatedAt, err := strconv.ParseInt(match[2], 10, 64)
-		if err != nil {
-			continue
-		}
-		out = append(out, localFile{name: entry.Name(), id: match[1], updatedAt: updatedAt})
+		out = append(out, localFile{name: entry.Name(), id: match[1], version: match[2]})
 	}
 	return out, nil
 }
@@ -333,15 +328,13 @@ func (s *Syncer) writeAtomic(ctx context.Context, id, tmp, final string) error {
 // strings stay UI-safe and bounded.
 func safeErrorMessage(s string) string { return redact.Path(s) }
 
-// SyncedFilename returns the canonical local name for an asset. Panics if
-// UpdatedAt is zero, since a zero timestamp produces an unparseable filename
-// and would loop forever in the diff. Callers must filter zero-timed assets
-// upstream (Immich's listOnce does).
+// SyncedFilename returns the canonical local name for an asset. Panics on an
+// empty Version, which would produce an unparseable name and loop in the diff.
 func SyncedFilename(a Asset) string {
-	if a.UpdatedAt.IsZero() {
-		panic("library: SyncedFilename requires non-zero UpdatedAt")
+	if a.Version == "" {
+		panic("library: SyncedFilename requires non-empty Version")
 	}
-	return a.ID + "-" + strconv.FormatInt(a.UpdatedAt.Unix(), 10) + ".jpg"
+	return a.ID + "-" + a.Version + ".jpg"
 }
 
 // IsSyncedName reports whether name matches the synced-file pattern.

--- a/internal/library/syncer_test.go
+++ b/internal/library/syncer_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -82,7 +83,7 @@ func setup(t *testing.T) (*os.Root, *library.Library) {
 }
 
 func asset(id string, ts int64) library.Asset {
-	return library.Asset{ID: id, UpdatedAt: time.Unix(ts, 0)}
+	return library.Asset{ID: id, Version: strconv.FormatInt(ts, 10)}
 }
 
 func names(t *testing.T, root *os.Root) []string {


### PR DESCRIPTION
<!-- The PR title becomes the squash commit, so write it as a Conventional Commit. -->

## Summary

Immich v3 removes `AlbumResponseDto.assets` (immich-app/immich#27835), so album sync would silently return zero assets on v3. Re-point the adapter's listing at the timeline API (`/timeline/buckets` + `/timeline/bucket`), which  works on both v2.7.x and v3, so.

Contributes to #24 , issue will be kept open until Immich V3 release.

### Changes
- Enumerate via the timeline API, change detection moves from `updatedAt` to a hash of each asset's `thumbhash`.
- Gate each sync on the album's ETag: a 304 serves the cached list, so unchanged albums skip re-enumeration.

Verified against a live v2.7.5 server. v3 stays a best-effort target until GA.

**Upgrading the first time to a version containing this change will result in a full album redownload**

## Checklist

- [x] Title follows Conventional Commits (`type(scope): summary`).
- [x] `make lint` and `make test` pass locally.
- [x] Tests cover the change, or it needs none (for example, docs only).
- [ ] `make generate` run if the API changed.
- [x] No breaking change in a minor or patch release (see CONTRIBUTING).
