### PR TITLE
fix(ble): fix stale connection handling

### DIFF
--- a/internal/sensors/ble/adapter/bluetooth.go
+++ b/internal/sensors/ble/adapter/bluetooth.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/godbus/dbus/v5"
@@ -18,6 +19,10 @@ import (
 type Bluetooth struct {
 	adapter   *bluetooth.Adapter
 	adapterID string // e.g. "hci0"
+	// connectMu serializes scan+dial: sources share one adapter and tinygo's scan
+	// state isn't concurrency-safe. Coupling: an absent device holds it for the
+	// whole scan window, delaying other sources' reconnects (ok for a few sensors).
+	connectMu sync.Mutex
 }
 
 // New enables the default system Bluetooth adapter (hci0).
@@ -34,14 +39,21 @@ func NewWithID(id string) (*Bluetooth, error) {
 	return &Bluetooth{adapter: a, adapterID: id}, nil
 }
 
-// Connect scans until the peripheral is seen (BlueZ only creates the device
-// object after an advertisement), then dials it and discovers the requested
-// UUIDs. ctx bounds the scan; the connect/discover phase can't be cancelled.
+// Connect scans until the peripheral advertises (BlueZ only creates the device
+// object then), dials it and discovers the requested UUIDs. ctx bounds the scan.
 func (b *Bluetooth) Connect(ctx context.Context, mac string, addressType string, uuids []string) (ble.Device, error) {
 	addr, err := parseAddress(mac, addressType)
 	if err != nil {
 		return nil, err
 	}
+
+	// Released before the poll loop, so sources connect in turn but poll at once.
+	b.connectMu.Lock()
+	defer b.connectMu.Unlock()
+
+	// Clear a phantom Connected:yes (a Disconnect that didn't land across a re-exec):
+	// tinygo's Connect short-circuits on it and hands back a dead link. Disconnect first.
+	b.clearStaleConnection(ctx, addr.String())
 
 	if err := b.scanUntilSeen(ctx, addr); err != nil {
 		return nil, fmt.Errorf("scan for %s: %w", mac, err)
@@ -61,6 +73,38 @@ func (b *Bluetooth) Connect(ctx context.Context, mac string, addressType string,
 	return &bleDevice{device: device, chars: chars}, nil
 }
 
+// clearStaleConnection disconnects mac if BlueZ still shows it Connected: the
+// phantom left when a Disconnect didn't land across a re-exec. Best-effort.
+func (b *Bluetooth) clearStaleConnection(ctx context.Context, mac string) {
+	// Shared bus tinygo's adapter also holds; reuse it, never Close it.
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		return
+	}
+	obj := conn.Object("org.bluez", deviceObjectPath(b.adapterID, mac))
+
+	// Bound the calls so a wedged BlueZ can't hang Connect indefinitely.
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	var v dbus.Variant
+	if err := obj.CallWithContext(ctx, "org.freedesktop.DBus.Properties.Get", 0,
+		"org.bluez.Device1", "Connected").Store(&v); err != nil {
+		return
+	}
+	if connected, ok := v.Value().(bool); !ok || !connected {
+		return
+	}
+	_ = obj.CallWithContext(ctx, "org.bluez.Device1.Disconnect", 0).Err
+}
+
+// deviceObjectPath builds a peripheral's BlueZ object path, matching tinygo's
+// format (uppercase MAC, colons to underscores).
+func deviceObjectPath(adapterID, mac string) dbus.ObjectPath {
+	devID := strings.ReplaceAll(strings.ToUpper(mac), ":", "_")
+	return dbus.ObjectPath(fmt.Sprintf("/org/bluez/%s/dev_%s", adapterID, devID))
+}
+
 // scanUntilSeen scans until the target is seen advertising, populating BlueZ's
 // device cache so Connect works.
 func (b *Bluetooth) scanUntilSeen(ctx context.Context, target bluetooth.Address) error {
@@ -75,7 +119,11 @@ func (b *Bluetooth) scanUntilSeen(ctx context.Context, target bluetooth.Address)
 			if strings.ToUpper(result.Address.String()) == targetMAC {
 				// Stop before signalling so the next Connect doesn't hit InProgress.
 				_ = a.StopScan()
-				found <- nil
+				// Non-blocking: a second match before StopScan lands mustn't block here.
+				select {
+				case found <- nil:
+				default:
+				}
 			}
 		})
 		// Scan() returns nil after StopScan; only forward real errors.
@@ -102,11 +150,16 @@ func (b *Bluetooth) scanUntilSeen(ctx context.Context, target bluetooth.Address)
 // Reset power-cycles the adapter via org.bluez.Adapter1 (tinygo-bluetooth has
 // no reset API; godbus does).
 func (b *Bluetooth) Reset(ctx context.Context) error {
+	// Same lock as Connect: power-cycling under another source's scan/dial aborts it.
+	b.connectMu.Lock()
+	defer b.connectMu.Unlock()
+
 	conn, err := dbus.SystemBus()
 	if err != nil {
 		return fmt.Errorf("dbus system bus: %w", err)
 	}
-	defer conn.Close()
+	// Don't Close: SystemBus is the shared connection tinygo's adapter holds for
+	// the process lifetime; closing it tears down the transport it scans over.
 
 	obj := conn.Object("org.bluez", dbus.ObjectPath("/org/bluez/"+b.adapterID))
 
@@ -163,8 +216,12 @@ func parseAddress(mac string, addressType string) (bluetooth.Address, error) {
 	}
 	var addr bluetooth.Address
 	addr.MAC = parsed
-	if strings.EqualFold(addressType, "random") {
+	switch strings.ToLower(strings.TrimSpace(addressType)) {
+	case "random":
 		addr.SetRandom(true)
+	case "public", "": // empty defaults to public
+	default:
+		return bluetooth.Address{}, fmt.Errorf("invalid address_type %q (want \"random\" or \"public\")", addressType)
 	}
 	return addr, nil
 }

--- a/internal/sensors/ble/adapter/bluetooth_test.go
+++ b/internal/sensors/ble/adapter/bluetooth_test.go
@@ -1,0 +1,81 @@
+//go:build linux
+
+package adapter
+
+import "testing"
+
+func TestParseAddress(t *testing.T) {
+	const mac = "AA:BB:CC:DD:EE:FF"
+	cases := []struct {
+		name        string
+		addressType string
+		wantRandom  bool
+		wantErr     bool
+	}{
+		{name: "random", addressType: "random", wantRandom: true},
+		{name: "public", addressType: "public", wantRandom: false},
+		{name: "case-insensitive", addressType: "Random", wantRandom: true},
+		{name: "empty defaults to public", addressType: "", wantRandom: false},
+		{name: "trims surrounding whitespace", addressType: "public ", wantRandom: false},
+		{name: "unknown type errors", addressType: "publik", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			addr, err := parseAddress(mac, tc.addressType)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseAddress(%q, %q) = nil error, want error", mac, tc.addressType)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseAddress(%q, %q) error: %v", mac, tc.addressType, err)
+			}
+			if addr.IsRandom() != tc.wantRandom {
+				t.Fatalf("parseAddress(%q, %q) IsRandom = %v, want %v", mac, tc.addressType, addr.IsRandom(), tc.wantRandom)
+			}
+		})
+	}
+}
+
+func TestParseAddressInvalidMAC(t *testing.T) {
+	if _, err := parseAddress("not-a-mac", "public"); err == nil {
+		t.Fatal("parseAddress with invalid MAC = nil error, want error")
+	}
+}
+
+func TestDeviceObjectPath(t *testing.T) {
+	cases := []struct {
+		name      string
+		adapterID string
+		mac       string
+		want      string
+	}{
+		{
+			name:      "uppercase mac",
+			adapterID: "hci0",
+			mac:       "D5:CE:E6:61:5B:1D",
+			want:      "/org/bluez/hci0/dev_D5_CE_E6_61_5B_1D",
+		},
+		{
+			name:      "lowercase mac is upcased to match bluez",
+			adapterID: "hci0",
+			mac:       "d5:ce:e6:61:5b:1d",
+			want:      "/org/bluez/hci0/dev_D5_CE_E6_61_5B_1D",
+		},
+		{
+			name:      "non-default adapter id",
+			adapterID: "hci1",
+			mac:       "AA:BB:CC:DD:EE:FF",
+			want:      "/org/bluez/hci1/dev_AA_BB_CC_DD_EE_FF",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(deviceObjectPath(tc.adapterID, tc.mac))
+			if got != tc.want {
+				t.Fatalf("deviceObjectPath(%q, %q) = %q, want %q", tc.adapterID, tc.mac, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/sensors/registry.go
+++ b/internal/sensors/registry.go
@@ -40,16 +40,30 @@ func (r *Registry) Run(ctx context.Context) {
 
 func (r *Registry) runSource(ctx context.Context, s Source) {
 	out := make(chan Reading, 8)
+	done := make(chan struct{})
 	var fanout sync.WaitGroup
 	fanout.Go(func() {
-		for reading := range out {
-			r.emit(reading)
+		for {
+			select {
+			case <-done:
+				// Deliver anything already buffered before exiting.
+				for {
+					select {
+					case reading := <-out:
+						r.emit(reading)
+					default:
+						return
+					}
+				}
+			case reading := <-out:
+				r.emit(reading)
+			}
 		}
 	})
-	// Close out and let the drain finish before returning, so no readings are
-	// still in flight when the source's WaitGroup entry completes.
+	// Don't close out: a source's async callbacks (BLE notifications) can fire
+	// after Start returns, and a send on a closed channel panics. done stops the drain.
 	defer func() {
-		close(out)
+		close(done)
 		fanout.Wait()
 	}()
 

--- a/internal/sensors/registry_test.go
+++ b/internal/sensors/registry_test.go
@@ -58,6 +58,41 @@ func (e *errSource) Start(ctx context.Context, out chan<- sensors.Reading) error
 	return nil
 }
 
+// capturingSource hands its out channel to the test, then blocks until ctx ends.
+type capturingSource struct {
+	id  string
+	got chan chan<- sensors.Reading
+}
+
+func (c *capturingSource) ID() string { return c.id }
+func (c *capturingSource) Start(ctx context.Context, out chan<- sensors.Reading) error {
+	c.got <- out
+	<-ctx.Done()
+	return nil
+}
+
+// A BLE GATT notification can fire after Start returns (tinygo Disconnect is
+// async); the registry must not close out under it or the late send panics.
+func TestRegistryDoesNotCloseOutWhileLateSendPossible(t *testing.T) {
+	src := &capturingSource{id: "cap", got: make(chan chan<- sensors.Reading, 1)}
+	reg := sensors.NewRegistry(testutil.NopLogger(), []sensors.Source{src}, func(sensors.Reading) {})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan struct{})
+	go func() { reg.Run(ctx); close(runDone) }()
+
+	out := <-src.got
+	cancel()
+	<-runDone
+
+	// out must stay open after the source stops: the late send must not panic or block.
+	select {
+	case out <- sensors.Reading{DeviceID: "cap"}:
+	case <-time.After(time.Second):
+		t.Fatal("late send blocked; out should remain open with buffer space")
+	}
+}
+
 func TestRegistryDeliverReadings(t *testing.T) {
 	want := []sensors.Reading{
 		{DeviceID: "a", Kind: sensors.KindTemperature, Value: 21.0},


### PR DESCRIPTION
<!-- The PR title becomes the squash commit, so write it as a Conventional Commit. -->

## Summary

- fixes an issue where a stale connectioncould stay lingering for a long time
- better concurrency handling
- stricter validation

## Checklist

- [x] Title follows Conventional Commits (`type(scope): summary`).
- [x] `make lint` and `make test` pass locally.
- [x] Tests cover the change, or it needs none (for example, docs only).
- [x] `make generate` run if the API changed.
- [x] No breaking change in a minor or patch release (see CONTRIBUTING).
