### PR TITLE
docs: remove goreportcard (retired)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ private, and plugged into Home Assistant.
 
 [![CI](https://github.com/MateEke/picture-frame/actions/workflows/ci.yml/badge.svg)](https://github.com/MateEke/picture-frame/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/MateEke/picture-frame?refresh=1)](https://github.com/MateEke/picture-frame/releases/latest)
-[![Go Report Card](https://goreportcard.com/badge/github.com/MateEke/picture-frame)](https://goreportcard.com/report/github.com/MateEke/picture-frame)
 [![License](https://img.shields.io/github/license/MateEke/picture-frame)](LICENSE)
 
 </div>


### PR DESCRIPTION
<!-- The PR title becomes the squash commit, so write it as a Conventional Commit. -->

## Summary

Removes goreportcard badge, since their project was archived - https://github.com/gojp/goreportcard/commit/176744ca23b40aa64c55b390161a3c78982e91b8.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): summary`).
- [ ] `make lint` and `make test` pass locally.
- [ ] Tests cover the change, or it needs none (for example, docs only).
- [ ] `make generate` run if the API changed.
- [ ] No breaking change in a minor or patch release (see CONTRIBUTING).
