### PR TITLE
feat: implement display rotation for wlopm backend

### DIFF
--- a/cmd/picture-frame/main.go
+++ b/cmd/picture-frame/main.go
@@ -122,6 +122,12 @@ func run() error {
 	// Screen: manual on/off shared by the HTTP API and MQTT bridge.
 	screen := displaypkg.NewScreen(policy)
 
+	// Apply configured rotation; if labwc isn't up yet the SSE-connect reconcile heals it.
+	rotator := newRotator(production, log, cfg)
+	if rotator != nil {
+		rotator.Reconcile(ctx)
+	}
+
 	libDir := libraryDir(cfg)
 	lib, err := libadapter.Load(log, libDir, cfg.Slideshow.Randomize)
 	if err != nil {
@@ -218,7 +224,7 @@ func run() error {
 		go mqttHub.Connect(ctx)
 	}
 
-	liveCfg := &liveConfigImpl{slideshow: slides, policy: policy, weather: weatherPoller, logLevel: &levelVar, log: log}
+	liveCfg := &liveConfigImpl{slideshow: slides, policy: policy, rotator: rotator, weather: weatherPoller, logLevel: &levelVar, log: log}
 
 	restartFn := startup.MakeRestartFunc(restartCh)
 	updaterSvc := startUpdater(ctx, log, cfg, production, restartFn)
@@ -229,6 +235,7 @@ func run() error {
 		Handler: httpapi.NewServer(httpapi.Config{
 			Log:           log,
 			Screen:        screen,
+			Rotator:       rotator,
 			Bus:           bus,
 			Library:       lib,
 			Slideshow:     slides,

--- a/cmd/picture-frame/wiring.go
+++ b/cmd/picture-frame/wiring.go
@@ -48,6 +48,15 @@ func newDisplay(production bool, log *slog.Logger, cfg *config.Config, screenSta
 	return display, displaypkg.NewFileIntentStore(screenStatePath), nil
 }
 
+// newRotator: wlr-randr in prod (nil on vcgencmd), a mock in dev;
+// ROTATION_MOCK=unsupported simulates missing wlr-randr for e2e.
+func newRotator(production bool, log *slog.Logger, cfg *config.Config) displaypkg.Rotator {
+	if !production {
+		return displaypkg.NewMockRotator(os.Getenv("ROTATION_MOCK") != "unsupported")
+	}
+	return startup.NewRotator(log, cfg.Display)
+}
+
 // kioskTimeoutFunc returns the watchdog's on-loss action: exit (→ systemd
 // restart) in prod, a warning no-op in dev.
 func kioskTimeoutFunc(production bool, log *slog.Logger) func() {
@@ -198,7 +207,8 @@ func mockUpdaterDelay() time.Duration {
 type liveConfigImpl struct {
 	slideshow *slideshow.Slideshow
 	policy    *displaypkg.Policy
-	weather   *weather.Poller // may be nil if api_key not configured
+	rotator   displaypkg.Rotator // nil on vcgencmd
+	weather   *weather.Poller    // may be nil if api_key not configured
 	logLevel  *slog.LevelVar
 	log       *slog.Logger
 }
@@ -208,6 +218,14 @@ func (l *liveConfigImpl) ApplyLive(cfg config.Config) {
 	l.slideshow.SetRandomize(cfg.Slideshow.Randomize)
 	l.slideshow.SetSplitConfig(cfg.Slideshow.SplitScreen, slideplan.Threshold{Factor: cfg.Slideshow.PairThreshold})
 	l.policy.SetBlankAfter(cfg.Display.BlankAfter.Duration)
+	if l.rotator != nil {
+		if err := l.rotator.Set(context.Background(), cfg.Display.Rotation); err != nil {
+			l.log.Warn("rotation apply failed", "err", err)
+		}
+		// wlr-randr's output commit can power a manually-off panel back on;
+		// re-assert desired power so state and panel stay consistent.
+		l.policy.Reconcile(context.Background())
+	}
 	if l.weather != nil {
 		l.weather.SetIntervals(cfg.Weather.PollInterval.Duration, cfg.Weather.RetryInterval.Duration)
 	}

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -324,7 +324,7 @@ determine_src_dir() {
 install_runtime_deps() {
     # seatd brokers seat/DRM access for the User= compositor/browser (no login session).
     local pkgs="seatd cog dnsmasq-base bluez avahi-daemon"
-    [ "$DISPLAY_BACKEND" = "wlopm" ] && pkgs="$pkgs labwc wlopm"
+    [ "$DISPLAY_BACKEND" = "wlopm" ] && pkgs="$pkgs labwc wlopm wlr-randr"
     log "installing runtime packages: $pkgs"
     # shellcheck disable=SC2086 # intentional word-splitting of the package list
     apt_install $pkgs

--- a/deploy/kiosk-browser-launch.sh
+++ b/deploy/kiosk-browser-launch.sh
@@ -22,5 +22,18 @@ for conn in /sys/class/drm/card*-*/status; do
     esac
 done
 
+# A 90/270 transform makes the logical output portrait but the pinned mode above
+# is the native landscape WxH; swap so cog matches. Missing file = no rotation.
+rot="$(cat "${XDG_RUNTIME_DIR:-/run/picture-frame}/rotation" 2>/dev/null || true)"
+if [ -n "${COG_PLATFORM_WL_VIEW_WIDTH:-}" ]; then
+    case "$rot" in
+    90 | 270)
+        swap="$COG_PLATFORM_WL_VIEW_WIDTH"
+        COG_PLATFORM_WL_VIEW_WIDTH="$COG_PLATFORM_WL_VIEW_HEIGHT"
+        COG_PLATFORM_WL_VIEW_HEIGHT="$swap"
+        ;;
+    esac
+fi
+
 # --webprocess-failure=restart recovers a renderer crash in place (no remap/flash).
 exec /usr/bin/cog -P wl --webprocess-failure=restart http://localhost:80/kiosk

--- a/deploy/systemd/kiosk-backend.service
+++ b/deploy/systemd/kiosk-backend.service
@@ -23,6 +23,9 @@ CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
 ProtectSystem=strict
 ReadWritePaths=@@INSTALL_DIR@@
+# Rotation intent file lives in labwc's runtime dir, read-only under strict
+# mode without this; "-" skips it on vcgencmd installs (no labwc).
+ReadWritePaths=-/run/picture-frame
 SupplementaryGroups=video bluetooth
 # ProtectSystem=strict makes the host /tmp read-only; give the backend its own
 # writable /tmp for upload multipart spills. Private tmpfs, wiped on restart.

--- a/docs/src/content/docs/manual/slideshow-display.md
+++ b/docs/src/content/docs/manual/slideshow-display.md
@@ -101,4 +101,22 @@ a connected display from the list or type the name.
 A change to the screen output takes effect after the frame restarts.
 :::
 
+## Screen rotation
+
+**Rotation** turns the whole picture to match how the frame hangs: landscape, portrait
+(rotated right or left), or upside down. It applies the moment you save, with no restart
+(`display.rotation`, degrees counter-clockwise, default `0`).
+
+Rotation changes what fits the screen, and the slideshow follows. On a portrait frame,
+portrait photos fill the screen on their own, and [split-screen pairing](#split-screen-pairing)
+pairs the landscape photos instead, stacked one above the other.
+
+Rotation is available on the default `wlopm` backend only.
+
+:::note[Installed before version 1.2.0?]
+Rotation needs the `wlr-randr` tool and an updated browser launch script, which software
+updates alone do not deliver. If the Rotation dropdown is greyed out, rerun the install
+script from [Install](/getting-started/install/); it keeps your settings and photos.
+:::
+
 Every setting on this page maps to a key in the [configuration reference](/reference/configuration/).

--- a/docs/src/content/docs/manual/updates.md
+++ b/docs/src/content/docs/manual/updates.md
@@ -18,6 +18,10 @@ are on. When one is available, a badge appears on the [Dashboard](/manual/dashbo
 Installing an update downloads it, verifies its signature and checksum, swaps it in, and restarts
 the frame on the new version.
 
+Updates replace the frame's program, not the system packages or boot scripts the installer
+set up. When a new feature needs one of those, its section in this manual says so; rerunning
+the install script brings everything current and keeps your settings.
+
 Automatic installs are limited to the **same version line**. Releases follow semantic
 versioning, written `major.minor.patch` (for example `1.4.2`). A new **minor or patch**, like
 `1.4.0` or `1.3.2`, only fixes or adds things and keeps working with your existing setup, so the

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -31,6 +31,7 @@ See [Slideshow & display](/manual/slideshow-display/).
 | `blank_after`     | duration | `20m`    | Idle time with no motion before the screen blanks. `0s` disables it. Needs a motion sensor. **(live)** |
 | `backend`         | string   | `wlopm`  | Screen-power backend, `wlopm` or `vcgencmd`. Switching it means re-running the installer.              |
 | `output`          | string   | (auto)   | Wayland connector for the wlopm backend, such as `HDMI-A-1`.                                           |
+| `rotation`        | integer  | `0`      | Counter-clockwise screen rotation: `0`, `90`, `180` or `270`. wlopm backend only. **(live)**           |
 | `locale`          | string   | `en-US`  | BCP-47 locale for the clock and date on the frame. **(live)**                                          |
 | `hide_clock_date` | boolean  | `false`  | Hide the clock and date on the frame. With no readings configured, the whole overlay hides. **(live)** |
 | `timezone`        | string   | (device) | IANA time zone for the clock and date, such as `Europe/Budapest`. Empty follows the device. **(live)** |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -119,6 +119,9 @@ type DisplayConfig struct {
 	// Output is the wlopm connector, e.g. "HDMI-A-1" (run `wlopm` to list);
 	// required for wlopm, ignored by vcgencmd.
 	Output string `toml:"output"`
+	// Rotation is the counter-clockwise screen rotation in degrees
+	// (0/90/180/270, wlr-randr transform semantics); wlopm only.
+	Rotation int `toml:"rotation"`
 	// Locale is the BCP-47 tag the kiosk formats the clock and date with; default "en-US".
 	Locale string `toml:"locale"`
 	// HideClockDate hides the clock and date block on the kiosk.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -591,6 +591,11 @@ func TestValidateDisplay(t *testing.T) {
 		{"empty timezone ok", config.DisplayConfig{Timezone: ""}, ""},
 		{"valid timezone", config.DisplayConfig{Timezone: "Europe/Budapest"}, ""},
 		{"unknown timezone", config.DisplayConfig{Timezone: "Not/AZone"}, "unknown timezone"},
+		{"rotation 90 ok", config.DisplayConfig{Rotation: 90}, ""},
+		{"rotation 180 ok", config.DisplayConfig{Rotation: 180}, ""},
+		{"rotation 270 ok", config.DisplayConfig{Rotation: 270}, ""},
+		{"rotation invalid", config.DisplayConfig{Rotation: 45}, "rotation must be"},
+		{"rotation negative", config.DisplayConfig{Rotation: -90}, "rotation must be"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -137,6 +137,11 @@ func (d DisplayConfig) validate() error {
 			return fmt.Errorf("unknown timezone %q: %w", d.Timezone, err)
 		}
 	}
+	switch d.Rotation {
+	case 0, 90, 180, 270:
+	default:
+		return fmt.Errorf("rotation must be 0, 90, 180 or 270, got %d", d.Rotation)
+	}
 	return nil
 }
 

--- a/internal/display/adapter/wlrrandr.go
+++ b/internal/display/adapter/wlrrandr.go
@@ -1,0 +1,150 @@
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// WlrRandr implements display.Rotator by shelling wlr-randr. One mutex spans
+// each whole operation so Set can't interleave with Reconcile's query-then-apply.
+type WlrRandr struct {
+	mu         sync.Mutex
+	log        *slog.Logger
+	output     string // connector name, e.g. "HDMI-A-1"
+	runtimeDir string // XDG_RUNTIME_DIR; "" skips intent-file writes (dev)
+	desired    int    // counter-clockwise degrees
+	applied    bool   // last exec for desired succeeded
+}
+
+// NewWlrRandr writes the intent file immediately: cog's launch script must see
+// it even before labwc is up.
+func NewWlrRandr(output string, desired int, runtimeDir string, log *slog.Logger) *WlrRandr {
+	w := &WlrRandr{log: log, output: output, runtimeDir: runtimeDir, desired: desired}
+	w.writeIntent()
+	return w
+}
+
+// A wedged compositor must fail the exec, not hang the save/SSE/startup paths
+// that hold w.mu.
+const execTimeout = 5 * time.Second
+
+// transformArg maps degrees to wlr-randr vocabulary ("0" is not accepted).
+func transformArg(degrees int) (string, error) {
+	switch degrees {
+	case 0:
+		return "normal", nil
+	case 90, 180, 270:
+		return strconv.Itoa(degrees), nil
+	default:
+		return "", fmt.Errorf("rotation must be 0, 90, 180 or 270, got %d", degrees)
+	}
+}
+
+func (w *WlrRandr) Supported() bool {
+	_, err := exec.LookPath("wlr-randr")
+	return err == nil
+}
+
+func (w *WlrRandr) Set(ctx context.Context, degrees int) error {
+	if _, err := transformArg(degrees); err != nil {
+		return err
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if degrees == w.desired && w.applied {
+		return nil // saves re-exec on unrelated config saves
+	}
+	w.desired = degrees
+	w.writeIntent()
+	return w.applyLocked(ctx)
+}
+
+func (w *WlrRandr) Reconcile(ctx context.Context) {
+	// No wlr-randr (pre-rotation install): skip silently, this runs on every SSE connect.
+	if !w.Supported() {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	want, _ := transformArg(w.desired) // desired is always valid here
+	current, err := w.queryLocked(ctx)
+	if err != nil {
+		w.log.Warn("wlr-randr: transform query failed", "err", err)
+		w.applied = false
+		return
+	}
+	if current == want {
+		w.applied = true
+		return
+	}
+	w.log.Info("wlr-randr: transform drifted, re-applying", "current", current, "want", want)
+	if err := w.applyLocked(ctx); err != nil {
+		w.log.Warn("wlr-randr: re-apply failed", "err", err)
+	}
+}
+
+func (w *WlrRandr) applyLocked(ctx context.Context) error {
+	arg, err := transformArg(w.desired)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, execTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "wlr-randr", "--output", w.output, "--transform", arg).CombinedOutput() //nolint:gosec
+	if err != nil {
+		w.applied = false
+		return fmt.Errorf("wlr-randr --transform %s on %s: %w (output: %s)", arg, w.output, err, out)
+	}
+	w.applied = true
+	w.log.Info("wlr-randr: transform applied", "output", w.output, "transform", arg)
+	return nil
+}
+
+func (w *WlrRandr) queryLocked(ctx context.Context) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, execTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "wlr-randr").CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("wlr-randr query: %w (output: %s)", err, out)
+	}
+	return parseTransform(out, w.output)
+}
+
+// parseTransform reads the connector block's indented "Transform:" line.
+func parseTransform(out []byte, connector string) (string, error) {
+	inBlock := false
+	for line := range strings.SplitSeq(string(out), "\n") {
+		indented := strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t")
+		if !indented {
+			first, _, _ := strings.Cut(strings.TrimSpace(line), " ")
+			inBlock = first == connector
+			continue
+		}
+		if !inBlock {
+			continue
+		}
+		if v, ok := strings.CutPrefix(strings.TrimSpace(line), "Transform:"); ok {
+			return strings.TrimSpace(v), nil
+		}
+	}
+	return "", fmt.Errorf("output %q not in wlr-randr listing", connector)
+}
+
+// writeIntent records desired rotation for kiosk-browser-launch.sh (intent, not state).
+func (w *WlrRandr) writeIntent() {
+	if w.runtimeDir == "" {
+		return
+	}
+	path := filepath.Join(w.runtimeDir, "rotation")
+	if err := os.WriteFile(path, []byte(strconv.Itoa(w.desired)), 0600); err != nil {
+		w.log.Warn("wlr-randr: intent file write failed", "path", path, "err", err)
+	}
+}

--- a/internal/display/adapter/wlrrandr_test.go
+++ b/internal/display/adapter/wlrrandr_test.go
@@ -1,0 +1,195 @@
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// installShim puts a fake wlr-randr on PATH: logs argv per call, prints
+// queryOutput for no-arg queries.
+func installShim(t *testing.T, queryOutput string) (argsFile string) {
+	t.Helper()
+	dir := t.TempDir()
+	argsFile = filepath.Join(dir, "args.log")
+	queryFile := filepath.Join(dir, "query.txt")
+	if err := os.WriteFile(queryFile, []byte(queryOutput), 0600); err != nil {
+		t.Fatal(err)
+	}
+	script := fmt.Sprintf("#!/bin/sh\necho \"$@\" >> %q\n[ $# -eq 0 ] && cat %q\nexit 0\n", argsFile, queryFile)
+	if err := os.WriteFile(filepath.Join(dir, "wlr-randr"), []byte(script), 0o700); err != nil { //nolint:gosec
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return argsFile
+}
+
+func shimCalls(t *testing.T, argsFile string) []string {
+	t.Helper()
+	data, err := os.ReadFile(argsFile)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Trailing newline only: a no-arg query logs an empty line that must survive.
+	return strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
+}
+
+const queryNormal = `HDMI-A-1 "Mock Panel"
+  Enabled: yes
+  Modes:
+    1920x1080 px, 60.000000 Hz (preferred, current)
+  Position: 0,0
+  Transform: normal
+  Scale: 1.000000
+`
+
+const query90 = `HDMI-A-1 "Mock Panel"
+  Enabled: yes
+  Transform: 90
+`
+
+func newTestRotator(t *testing.T, desired int) (*WlrRandr, string) {
+	t.Helper()
+	runtimeDir := t.TempDir()
+	r := NewWlrRandr("HDMI-A-1", desired, runtimeDir, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	return r, filepath.Join(runtimeDir, "rotation")
+}
+
+func TestWlrRandrSetInvokesTransform(t *testing.T) {
+	argsFile := installShim(t, queryNormal)
+	r, intentPath := newTestRotator(t, 0)
+
+	if err := r.Set(context.Background(), 90); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	calls := shimCalls(t, argsFile)
+	if len(calls) != 1 || calls[0] != "--output HDMI-A-1 --transform 90" {
+		t.Errorf("calls = %q, want one '--output HDMI-A-1 --transform 90'", calls)
+	}
+	intent, err := os.ReadFile(intentPath)
+	if err != nil || string(intent) != "90" {
+		t.Errorf("intent file = %q, %v; want \"90\"", intent, err)
+	}
+}
+
+func TestWlrRandrSetMapsZeroToNormal(t *testing.T) {
+	argsFile := installShim(t, queryNormal)
+	r, _ := newTestRotator(t, 90)
+
+	if err := r.Set(context.Background(), 0); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	calls := shimCalls(t, argsFile)
+	if len(calls) != 1 || calls[0] != "--output HDMI-A-1 --transform normal" {
+		t.Errorf("calls = %q, want '--output HDMI-A-1 --transform normal'", calls)
+	}
+}
+
+func TestWlrRandrSetRejectsInvalidDegrees(t *testing.T) {
+	installShim(t, queryNormal)
+	r, _ := newTestRotator(t, 0)
+	if err := r.Set(context.Background(), 45); err == nil {
+		t.Fatal("expected error for 45 degrees")
+	}
+}
+
+func TestWlrRandrSetSkipsWhenAlreadyApplied(t *testing.T) {
+	argsFile := installShim(t, queryNormal)
+	r, _ := newTestRotator(t, 0)
+
+	if err := r.Set(context.Background(), 90); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Set(context.Background(), 90); err != nil {
+		t.Fatal(err)
+	}
+	if calls := shimCalls(t, argsFile); len(calls) != 1 {
+		t.Errorf("got %d exec calls, want 1 (second Set is a no-op)", len(calls))
+	}
+}
+
+func TestWlrRandrReconcileAppliesOnDrift(t *testing.T) {
+	argsFile := installShim(t, queryNormal) // compositor says normal
+	r, _ := newTestRotator(t, 90)           // desired 90
+
+	r.Reconcile(context.Background())
+	calls := shimCalls(t, argsFile)
+	// One query (logged as an empty line) + one set.
+	want := "--output HDMI-A-1 --transform 90"
+	if len(calls) != 2 || strings.TrimSpace(calls[0]) != "" || calls[1] != want {
+		t.Errorf("calls = %q, want [query, %q]", calls, want)
+	}
+}
+
+func TestWlrRandrReconcileSkipsWhenUnsupported(t *testing.T) {
+	argsFile := installShim(t, queryNormal)
+	r, _ := newTestRotator(t, 90)
+
+	t.Setenv("PATH", t.TempDir()) // wlr-randr gone
+	r.Reconcile(context.Background())
+	if calls := shimCalls(t, argsFile); len(calls) != 0 {
+		t.Errorf("calls = %q, want none when unsupported", calls)
+	}
+}
+
+func TestWlrRandrReconcileNoopWithoutDrift(t *testing.T) {
+	argsFile := installShim(t, query90)
+	r, _ := newTestRotator(t, 90)
+
+	r.Reconcile(context.Background())
+	calls := shimCalls(t, argsFile)
+	if len(calls) != 1 || strings.TrimSpace(calls[0]) != "" {
+		t.Errorf("calls = %q, want only the query", calls)
+	}
+}
+
+func TestWlrRandrIntentWrittenOnConstruction(t *testing.T) {
+	installShim(t, queryNormal)
+	_, intentPath := newTestRotator(t, 270)
+	intent, err := os.ReadFile(intentPath)
+	if err != nil || string(intent) != "270" {
+		t.Errorf("intent file = %q, %v; want \"270\" at construction", intent, err)
+	}
+}
+
+func TestWlrRandrSupported(t *testing.T) {
+	r, _ := newTestRotator(t, 0)
+	t.Setenv("PATH", t.TempDir())
+	if r.Supported() {
+		t.Error("Supported() = true with empty PATH")
+	}
+	installShim(t, queryNormal)
+	if !r.Supported() {
+		t.Error("Supported() = false with shim on PATH (must re-check per call)")
+	}
+}
+
+func TestParseTransform(t *testing.T) {
+	cases := []struct {
+		name, out, connector, want string
+		wantErr                    bool
+	}{
+		{"normal", queryNormal, "HDMI-A-1", "normal", false},
+		{"rotated", query90, "HDMI-A-1", "90", false},
+		{"other connector only", query90, "HDMI-A-2", "", true},
+		{"empty", "", "HDMI-A-1", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseTransform([]byte(tc.out), tc.connector)
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("err = %v, wantErr %v", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/display/mock.go
+++ b/internal/display/mock.go
@@ -68,3 +68,34 @@ func (m *Mock) Calls() (on, off int) {
 	defer m.mu.Unlock()
 	return m.onCalls, m.offCalls
 }
+
+// MockRotator is the dev/test Rotator: records calls, never execs.
+type MockRotator struct {
+	mu         sync.Mutex
+	supported  bool
+	degrees    int
+	reconciles int
+}
+
+func NewMockRotator(supported bool) *MockRotator { return &MockRotator{supported: supported} }
+
+func (m *MockRotator) Set(_ context.Context, degrees int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.degrees = degrees
+	return nil
+}
+
+func (m *MockRotator) Reconcile(_ context.Context) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.reconciles++
+}
+
+func (m *MockRotator) Supported() bool { return m.supported }
+
+// Degrees is the last Set value.
+func (m *MockRotator) Degrees() int { m.mu.Lock(); defer m.mu.Unlock(); return m.degrees }
+
+// Reconciles counts Reconcile calls.
+func (m *MockRotator) Reconciles() int { m.mu.Lock(); defer m.mu.Unlock(); return m.reconciles }

--- a/internal/display/mock_test.go
+++ b/internal/display/mock_test.go
@@ -1,0 +1,32 @@
+package display_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MateEke/picture-frame/internal/display"
+)
+
+func TestMockRotatorRecordsSetAndReconcile(t *testing.T) {
+	m := display.NewMockRotator(true)
+	if !m.Supported() {
+		t.Error("Supported() = false, want true")
+	}
+	if err := m.Set(context.Background(), 90); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if got := m.Degrees(); got != 90 {
+		t.Errorf("Degrees() = %d, want 90", got)
+	}
+	m.Reconcile(context.Background())
+	m.Reconcile(context.Background())
+	if got := m.Reconciles(); got != 2 {
+		t.Errorf("Reconciles() = %d, want 2", got)
+	}
+}
+
+func TestMockRotatorUnsupported(t *testing.T) {
+	if display.NewMockRotator(false).Supported() {
+		t.Error("Supported() = true, want false")
+	}
+}

--- a/internal/display/rotator.go
+++ b/internal/display/rotator.go
@@ -1,0 +1,16 @@
+package display
+
+import "context"
+
+// Rotator applies the output transform. Nil when the backend can't rotate
+// (vcgencmd); callers must nil-check.
+type Rotator interface {
+	// Set applies the rotation now (0/90/180/270 counter-clockwise degrees).
+	Set(ctx context.Context, degrees int) error
+	// Reconcile re-applies only on drift (query-first), so it can run on
+	// every SSE connect.
+	Reconcile(ctx context.Context)
+	// Supported re-checks per call, so a post-install of wlr-randr is
+	// noticed without a restart.
+	Supported() bool
+}

--- a/internal/httpapi/config.go
+++ b/internal/httpapi/config.go
@@ -29,6 +29,7 @@ func copyTier1(dst *config.Config, src config.Config) {
 	dst.Display.Locale = src.Display.Locale // re-published on the kiosk SSE event
 	dst.Display.HideClockDate = src.Display.HideClockDate
 	dst.Display.Timezone = src.Display.Timezone
+	dst.Display.Rotation = src.Display.Rotation // applied live via Rotator.Set
 	dst.Display.Labels = src.Display.Labels
 	dst.Slideshow.Interval = src.Slideshow.Interval
 	dst.Slideshow.Randomize = src.Slideshow.Randomize

--- a/internal/httpapi/configdto.go
+++ b/internal/httpapi/configdto.go
@@ -68,6 +68,7 @@ type DisplayDTO struct {
 	BlankAfter    string         `json:"blank_after" doc:"Idle duration before screen blanks, e.g. \"20m\""`
 	Backend       string         `json:"backend" enum:"wlopm,vcgencmd"`
 	Output        string         `json:"output" doc:"Wayland connector name, e.g. \"HDMI-A-1\" (wlopm only)"`
+	Rotation      int            `json:"rotation" enum:"0,90,180,270" doc:"Counter-clockwise screen rotation in degrees (wlopm only); applied live via wlr-randr"`
 	Locale        string         `json:"locale" doc:"BCP-47 date/time locale for the kiosk clock, e.g. en-US"`
 	HideClockDate bool           `json:"hide_clock_date" doc:"Hide the clock and date block on the kiosk overlay"`
 	Timezone      string         `json:"timezone" doc:"IANA timezone for the kiosk clock/date, e.g. Europe/Budapest; empty uses the browser timezone"`
@@ -191,6 +192,7 @@ func toDTO(cfg config.Config) ConfigDTO {
 			BlankAfter:    durString(cfg.Display.BlankAfter.Duration),
 			Backend:       cfg.Display.Backend,
 			Output:        cfg.Display.Output,
+			Rotation:      cfg.Display.Rotation,
 			Locale:        cfg.Display.Locale,
 			HideClockDate: cfg.Display.HideClockDate,
 			Timezone:      cfg.Display.Timezone,
@@ -320,6 +322,7 @@ func applyDisplayDTO(dst *config.DisplayConfig, dto DisplayDTO) error {
 	dst.BlankAfter = blankAfter
 	dst.Backend = dto.Backend
 	dst.Output = dto.Output
+	dst.Rotation = dto.Rotation
 	dst.Locale = dto.Locale
 	dst.HideClockDate = dto.HideClockDate
 	dst.Timezone = dto.Timezone

--- a/internal/httpapi/configdto_test.go
+++ b/internal/httpapi/configdto_test.go
@@ -222,6 +222,23 @@ func TestUpdaterDTOClearsToken(t *testing.T) {
 	}
 }
 
+func TestDisplayRotationRoundTrip(t *testing.T) {
+	cfg := fullTestConfig()
+	cfg.Display.Rotation = 90
+	dto := toDTO(cfg)
+	if dto.Display.Rotation != 90 {
+		t.Fatalf("toDTO rotation = %d, want 90", dto.Display.Rotation)
+	}
+	dto.Display.Rotation = 270
+	out, err := applyDTO(dto, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Display.Rotation != 270 {
+		t.Errorf("applyDTO rotation = %d, want 270", out.Display.Rotation)
+	}
+}
+
 func TestUpdaterDTORejectsBadHour(t *testing.T) {
 	// fullTestConfig is valid everywhere else, so the bad hour is the only possible error.
 	dto := toDTO(fullTestConfig())
@@ -502,6 +519,7 @@ func TestNeedsRestartTier1FieldsAreLive(t *testing.T) {
 		{"display.locale", func(c *config.Config) { c.Display.Locale = "hu-HU" }},
 		{"display.hide_clock_date", func(c *config.Config) { c.Display.HideClockDate = !c.Display.HideClockDate }},
 		{"display.timezone", func(c *config.Config) { c.Display.Timezone = "America/New_York" }},
+		{"display.rotation", func(c *config.Config) { c.Display.Rotation = 90 }},
 		{"display.labels", func(c *config.Config) { c.Display.Labels.Outside = "Garden" }},
 		{"slideshow.interval", func(c *config.Config) { c.Slideshow.Interval = config.Duration{Duration: 5 * time.Minute} }},
 		{"slideshow.randomize", func(c *config.Config) { c.Slideshow.Randomize = !c.Slideshow.Randomize }},

--- a/internal/httpapi/devices.go
+++ b/internal/httpapi/devices.go
@@ -22,6 +22,7 @@ var hciAdapterRe = regexp.MustCompile(`^hci[0-9]+$`)
 type SystemDevicesBody struct {
 	BluetoothAdapters []string `json:"bluetooth_adapters" doc:"HCI device IDs, e.g. hci0"`
 	DisplayOutputs    []string `json:"display_outputs" doc:"Connected display connectors, e.g. HDMI-A-1"`
+	RotationSupported bool     `json:"rotation_supported" doc:"true when the display backend can rotate and wlr-randr is installed"`
 }
 
 type getSystemDevicesOutput struct {
@@ -35,7 +36,9 @@ func (s *server) registerDeviceRoutes(api huma.API) {
 		Path:        "/api/system/devices",
 		Summary:     "Enumerate Bluetooth adapters and display outputs from sysfs",
 	}, func(_ context.Context, _ *struct{}) (*getSystemDevicesOutput, error) {
-		return &getSystemDevicesOutput{Body: enumerateDevices(s.sysfsBase)}, nil
+		body := enumerateDevices(s.sysfsBase)
+		body.RotationSupported = s.rotator != nil && s.rotator.Supported()
+		return &getSystemDevicesOutput{Body: body}, nil
 	})
 }
 

--- a/internal/httpapi/devices_test.go
+++ b/internal/httpapi/devices_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"testing"
 
+	displaypkg "github.com/MateEke/picture-frame/internal/display"
 	"github.com/MateEke/picture-frame/internal/httpapi"
 	"github.com/MateEke/picture-frame/internal/state"
 	"github.com/MateEke/picture-frame/internal/testutil"
@@ -106,5 +107,41 @@ func TestEnumerateDevicesMissingSysfsIsEmpty(t *testing.T) {
 	}
 	if len(body.DisplayOutputs) != 0 {
 		t.Errorf("display_outputs: got %v, want empty", body.DisplayOutputs)
+	}
+}
+
+func TestDevicesRotationSupported(t *testing.T) {
+	cases := []struct {
+		name    string
+		rotator httpapi.RotationController
+		want    bool
+	}{
+		{"nil rotator", nil, false},
+		{"unsupported", displaypkg.NewMockRotator(false), false},
+		{"supported", displaypkg.NewMockRotator(true), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httpapi.NewServer(httpapi.Config{
+				Log:         testutil.NopLogger(),
+				Screen:      &mockScreen{},
+				Bus:         state.NewBus(),
+				KioskBeater: &fakeBeater{},
+				SysfsBase:   filepath.Join(t.TempDir(), "absent"),
+				Rotator:     tc.rotator,
+			})
+			rec := httptest.NewRecorder()
+			srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/system/devices", nil))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status %d", rec.Code)
+			}
+			var body httpapi.SystemDevicesBody
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatal(err)
+			}
+			if body.RotationSupported != tc.want {
+				t.Errorf("rotation_supported = %v, want %v", body.RotationSupported, tc.want)
+			}
+		})
 	}
 }

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -35,6 +35,14 @@ type ScreenController interface {
 	Reconcile(ctx context.Context)
 }
 
+// RotationController is implemented by display.Rotator; nil when the backend
+// can't rotate.
+type RotationController interface {
+	Set(ctx context.Context, degrees int) error
+	Reconcile(ctx context.Context)
+	Supported() bool
+}
+
 // SlideshowController allows the HTTP layer to drive slideshow playback.
 type SlideshowController interface {
 	Next()
@@ -63,6 +71,7 @@ type SyncerStatus = library.SyncerStatus
 type Config struct {
 	Log         *slog.Logger
 	Screen      ScreenController
+	Rotator     RotationController // nil when the display backend can't rotate
 	Bus         *state.Bus
 	Library     *library.Library
 	Slideshow   SlideshowController
@@ -101,6 +110,7 @@ type Config struct {
 type server struct {
 	log           *slog.Logger
 	screen        ScreenController
+	rotator       RotationController
 	bus           *state.Bus
 	lib           *library.Library
 	slideshow     SlideshowController
@@ -143,6 +153,7 @@ func NewServer(cfg Config) http.Handler {
 	s := &server{
 		log:           cfg.Log,
 		screen:        cfg.Screen,
+		rotator:       cfg.Rotator,
 		bus:           cfg.Bus,
 		lib:           cfg.Library,
 		slideshow:     cfg.Slideshow,

--- a/internal/httpapi/sse.go
+++ b/internal/httpapi/sse.go
@@ -51,6 +51,11 @@ func (s *server) streamEvents(ctx context.Context, send sse.Sender) {
 	ch, unsub := s.bus.Subscribe()
 	defer unsub()
 
+	// Rotator first: its drift-apply can power a manually-off panel back on,
+	// and the screen reconcile then re-asserts desired power.
+	if s.rotator != nil {
+		s.rotator.Reconcile(ctx)
+	}
 	s.screen.Reconcile(ctx)
 
 	maxSnapshotID := s.sendSnapshot(send)

--- a/internal/httpapi/sse_test.go
+++ b/internal/httpapi/sse_test.go
@@ -2,13 +2,17 @@ package httpapi_test
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	displaypkg "github.com/MateEke/picture-frame/internal/display"
 	"github.com/MateEke/picture-frame/internal/httpapi"
 	"github.com/MateEke/picture-frame/internal/state"
 	"github.com/MateEke/picture-frame/internal/testutil"
@@ -214,5 +218,76 @@ func collectSSEBlock(t *testing.T, scanner *bufio.Scanner, timeout time.Duration
 	case <-time.After(timeout):
 		t.Fatal("timeout waiting for SSE block")
 		return ""
+	}
+}
+
+func TestSSERotatorReconcilesOnConnect(t *testing.T) {
+	rot := displaypkg.NewMockRotator(true)
+	srv := httptest.NewServer(httpapi.NewServer(httpapi.Config{
+		Log:     testutil.NopLogger(),
+		Screen:  &mockScreen{},
+		Bus:     state.NewBus(),
+		Rotator: rot,
+	}))
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	// Headers arrive only after handleEvents runs the reconciles + flushes.
+	if got := rot.Reconciles(); got != 1 {
+		t.Errorf("expected exactly 1 rotator reconcile on connect, got %d", got)
+	}
+}
+
+// reconcileOrder records cross-goroutine reconcile sequencing.
+type reconcileOrder struct {
+	mu  sync.Mutex
+	seq []string
+}
+
+func (o *reconcileOrder) add(s string) { o.mu.Lock(); defer o.mu.Unlock(); o.seq = append(o.seq, s) }
+func (o *reconcileOrder) get() []string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return slices.Clone(o.seq)
+}
+
+type orderScreen struct {
+	mockScreen
+	ord *reconcileOrder
+}
+
+func (s *orderScreen) Reconcile(context.Context) { s.ord.add("screen") }
+
+type orderRotator struct{ ord *reconcileOrder }
+
+func (r *orderRotator) Set(context.Context, int) error { return nil }
+func (r *orderRotator) Reconcile(context.Context)      { r.ord.add("rotator") }
+func (r *orderRotator) Supported() bool                { return true }
+
+// The rotator's drift-apply can power a manually-off panel back on, so the
+// screen reconcile must run after it to re-assert desired power.
+func TestSSERotatorReconcilesBeforeScreen(t *testing.T) {
+	ord := &reconcileOrder{}
+	srv := httptest.NewServer(httpapi.NewServer(httpapi.Config{
+		Log:     testutil.NopLogger(),
+		Screen:  &orderScreen{ord: ord},
+		Bus:     state.NewBus(),
+		Rotator: &orderRotator{ord: ord},
+	}))
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if got := ord.get(); !slices.Equal(got, []string{"rotator", "screen"}) {
+		t.Errorf("reconcile order = %v, want [rotator screen]", got)
 	}
 }

--- a/internal/startup/backends.go
+++ b/internal/startup/backends.go
@@ -3,6 +3,7 @@ package startup
 import (
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/MateEke/picture-frame/internal/config"
 	displaypkg "github.com/MateEke/picture-frame/internal/display"
@@ -28,6 +29,14 @@ func NewDisplayController(log *slog.Logger, cfg config.DisplayConfig) (displaypk
 	default:
 		return nil, fmt.Errorf("unknown display backend %q", cfg.Backend)
 	}
+}
+
+// NewRotator builds the wlr-randr rotator; nil on vcgencmd (nothing to rotate).
+func NewRotator(log *slog.Logger, cfg config.DisplayConfig) displaypkg.Rotator {
+	if cfg.Backend != "" && cfg.Backend != config.DisplayBackendWlopm {
+		return nil
+	}
+	return displayadapter.NewWlrRandr(cfg.Output, cfg.Rotation, os.Getenv("XDG_RUNTIME_DIR"), log)
 }
 
 // WeatherEnabled reports whether a weather fetcher runs: real OWM when an api_key

--- a/internal/startup/backends_test.go
+++ b/internal/startup/backends_test.go
@@ -93,3 +93,19 @@ func TestBuildWeatherFetcher(t *testing.T) {
 		})
 	}
 }
+
+func TestNewRotatorWlopm(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir()) // keep the intent file out of the real runtime dir
+	if r := startup.NewRotator(testutil.NopLogger(), config.DisplayConfig{Backend: config.DisplayBackendWlopm, Output: "HDMI-A-1"}); r == nil {
+		t.Error("wlopm: expected a rotator")
+	}
+	if r := startup.NewRotator(testutil.NopLogger(), config.DisplayConfig{Backend: "", Output: "HDMI-A-1"}); r == nil {
+		t.Error("empty backend (defaults to wlopm): expected a rotator")
+	}
+}
+
+func TestNewRotatorVcgencmdNil(t *testing.T) {
+	if r := startup.NewRotator(testutil.NopLogger(), config.DisplayConfig{Backend: config.DisplayBackendVcgencmd}); r != nil {
+		t.Error("vcgencmd: expected nil rotator")
+	}
+}

--- a/web/e2e/pages/settings.page.ts
+++ b/web/e2e/pages/settings.page.ts
@@ -9,6 +9,8 @@ export class SettingsPage {
 	readonly splitScreenSwitch: Locator;
 	readonly hideClockDateSwitch: Locator;
 	readonly timezone: Locator;
+	readonly rotation: Locator;
+	readonly rotationHint: Locator;
 	readonly weatherLat: Locator;
 	readonly sensorAdd: Locator;
 	readonly dialogId: Locator;
@@ -46,6 +48,8 @@ export class SettingsPage {
 		this.splitScreenSwitch = page.getByTestId('split-screen-switch');
 		this.hideClockDateSwitch = page.getByTestId('hide-clock-date-switch');
 		this.timezone = page.getByTestId('setting-timezone');
+		this.rotation = page.getByTestId('setting-rotation');
+		this.rotationHint = page.getByTestId('setting-rotation-hint');
 		this.weatherLat = page.getByTestId('setting-weather-lat');
 		this.sensorAdd = page.getByTestId('sensor-add');
 		this.dialogId = page.getByTestId('sensor-dialog-id');

--- a/web/e2e/server.ts
+++ b/web/e2e/server.ts
@@ -26,6 +26,8 @@ export type ServerOptions = {
 	timezone?: string;
 	/** Drop sensors and the [weather] block so the overlay can go fully empty. */
 	minimalOverlay?: boolean;
+	/** ROTATION_MOCK=unsupported → rotation select disabled with the install hint. */
+	rotationUnsupported?: boolean;
 };
 
 export type PfServer = {
@@ -73,6 +75,7 @@ async function spawnOnce(opts: ServerOptions): Promise<PfServer> {
 	if (opts.updateLatest) env.UPDATER_MOCK_LATEST = opts.updateLatest;
 	if (opts.updateOutcome) env.UPDATER_MOCK_OUTCOME = opts.updateOutcome;
 	if (opts.updateOffline) env.UPDATER_MOCK_OFFLINE = '1';
+	if (opts.rotationUnsupported) env.ROTATION_MOCK = 'unsupported';
 
 	const proc = spawn(
 		binaryPath(),

--- a/web/e2e/settings.spec.ts
+++ b/web/e2e/settings.spec.ts
@@ -68,6 +68,21 @@ test.describe('settings', () => {
 		await expect(settings.timezone).toHaveValue(/Asia\/Tokyo/);
 	});
 
+	test('changes rotation, applies live and persists', async ({ page, settings }) => {
+		await settings.openSection('display');
+		await settings.rotation.selectOption('90');
+		await expect(settings.save).toBeEnabled();
+
+		await settings.save.click();
+		await expect(settings.saveBar).toBeHidden();
+		// Live field: no restart prompt.
+		await expect(settings.restartDialog).toBeHidden();
+
+		await page.reload();
+		await settings.openSection('display');
+		await expect(settings.rotation).toHaveValue('90');
+	});
+
 	test('links to the manual', async ({ settings }) => {
 		await expect(settings.docs).toHaveAttribute('href', /pictureframe\.ekemate\.hu\/manual/);
 	});
@@ -229,5 +244,17 @@ test.describe('settings security (already protected)', () => {
 		await settings.securityCurrent.fill('wrong-password');
 		await settings.securityDisable.click();
 		await expect(settings.securityDisableError).toBeVisible();
+	});
+});
+
+// Own server: the dev mock rotator reports no wlr-randr.
+test.describe('rotation unsupported', () => {
+	test.use({ serverOptions: { rotationUnsupported: true } });
+
+	test('rotation select is disabled with the install hint', async ({ settings }) => {
+		await settings.goto();
+		await settings.openSection('display');
+		await expect(settings.rotation).toBeDisabled();
+		await expect(settings.rotationHint).toBeVisible();
 	});
 });

--- a/web/openapi.json
+++ b/web/openapi.json
@@ -407,6 +407,17 @@
             "description": "Wayland connector name, e.g. \"HDMI-A-1\" (wlopm only)",
             "type": "string"
           },
+          "rotation": {
+            "description": "Counter-clockwise screen rotation in degrees (wlopm only); applied live via wlr-randr",
+            "enum": [
+              0,
+              90,
+              180,
+              270
+            ],
+            "format": "int64",
+            "type": "integer"
+          },
           "timezone": {
             "description": "IANA timezone for the kiosk clock/date, e.g. Europe/Budapest; empty uses the browser timezone",
             "type": "string"
@@ -416,6 +427,7 @@
           "blank_after",
           "backend",
           "output",
+          "rotation",
           "locale",
           "hide_clock_date",
           "timezone",
@@ -1182,11 +1194,16 @@
               "array",
               "null"
             ]
+          },
+          "rotation_supported": {
+            "description": "true when the display backend can rotate and wlr-randr is installed",
+            "type": "boolean"
           }
         },
         "required": [
           "bluetooth_adapters",
-          "display_outputs"
+          "display_outputs",
+          "rotation_supported"
         ],
         "type": "object"
       },

--- a/web/src/lib/api/types.gen.ts
+++ b/web/src/lib/api/types.gen.ts
@@ -143,6 +143,10 @@ export type DisplayDto = {
      */
     output: string;
     /**
+     * Counter-clockwise screen rotation in degrees (wlopm only); applied live via wlr-randr
+     */
+    rotation: 0 | 90 | 180 | 270;
+    /**
      * IANA timezone for the kiosk clock/date, e.g. Europe/Budapest; empty uses the browser timezone
      */
     timezone: string;
@@ -463,6 +467,10 @@ export type SystemDevicesBody = {
      * Connected display connectors, e.g. HDMI-A-1
      */
     display_outputs: Array<string> | null;
+    /**
+     * true when the display backend can rotate and wlr-randr is installed
+     */
+    rotation_supported: boolean;
 };
 
 export type SystemInfoBody = {
@@ -798,6 +806,10 @@ export type SystemDevicesBodyWritable = {
      * Connected display connectors, e.g. HDMI-A-1
      */
     display_outputs: Array<string> | null;
+    /**
+     * true when the display backend can rotate and wlr-randr is installed
+     */
+    rotation_supported: boolean;
 };
 
 export type SystemInfoBodyWritable = {

--- a/web/src/lib/config.test.ts
+++ b/web/src/lib/config.test.ts
@@ -29,6 +29,7 @@ const sampleConfig = {
 		blank_after: '20m0s',
 		backend: 'wlopm' as const,
 		output: 'HDMI-A-1',
+		rotation: 0 as const,
 		locale: 'en-US',
 		hide_clock_date: false,
 		timezone: '',

--- a/web/src/routes/admin/settings/+page.svelte
+++ b/web/src/routes/admin/settings/+page.svelte
@@ -94,7 +94,8 @@
 	// Per-section dirty flags surface changes hidden inside collapsed panels.
 	const displayDirty = $derived(
 		draft.display.backend !== savedConfig.display.backend ||
-			draft.display.output !== savedConfig.display.output
+			draft.display.output !== savedConfig.display.output ||
+			draft.display.rotation !== savedConfig.display.rotation
 	);
 	const libraryDirty = $derived(
 		!eq(draft.library, savedConfig.library) ||
@@ -120,6 +121,7 @@
 	function revertDisplay() {
 		draft.display.backend = savedConfig.display.backend;
 		draft.display.output = savedConfig.display.output;
+		draft.display.rotation = savedConfig.display.rotation;
 	}
 	function revertLibrary() {
 		draft.library = $state.snapshot(savedConfig.library);
@@ -291,6 +293,7 @@
 								bind:display={draft.display}
 								savedDisplay={savedConfig.display}
 								{outputs}
+								rotationSupported={data.devices?.rotation_supported ?? true}
 							/>
 						</div>
 					</Accordion.ItemContent>

--- a/web/src/routes/admin/settings/components/DisplayCard.svelte
+++ b/web/src/routes/admin/settings/components/DisplayCard.svelte
@@ -6,8 +6,23 @@
 	let {
 		display = $bindable(),
 		savedDisplay,
-		outputs
-	}: { display: DisplayDto; savedDisplay: DisplayDto; outputs: string[] } = $props();
+		outputs,
+		rotationSupported
+	}: {
+		display: DisplayDto;
+		savedDisplay: DisplayDto;
+		outputs: string[];
+		rotationSupported: boolean;
+	} = $props();
+
+	// wlr-randr transform degrees (counter-clockwise, per Wayland); labels by
+	// visible effect, confirmed on-device.
+	const ROTATIONS = [
+		{ value: 0, label: 'Landscape (0°)' },
+		{ value: 90, label: 'Portrait, rotated left (90°)' },
+		{ value: 180, label: 'Upside down (180°)' },
+		{ value: 270, label: 'Portrait, rotated right (270°)' }
+	];
 </script>
 
 <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
@@ -32,6 +47,29 @@
 			onrevert={() => (display.output = savedDisplay.output)}
 		>
 			<DeviceCombobox bind:value={display.output} options={outputs} placeholder="HDMI-A-1" />
+		</Field>
+		<Field
+			label="Rotation"
+			help="Physical screen rotation, applied live. In portrait, portrait photos fill the screen and landscape photos pair up."
+			class="md:col-span-2"
+			changed={display.rotation !== savedDisplay.rotation}
+			onrevert={() => (display.rotation = savedDisplay.rotation)}
+		>
+			<select
+				class="select"
+				bind:value={display.rotation}
+				disabled={!rotationSupported}
+				data-testid="setting-rotation"
+			>
+				{#each ROTATIONS as r (r.value)}
+					<option value={r.value}>{r.label}</option>
+				{/each}
+			</select>
+			{#if !rotationSupported}
+				<p class="text-surface-500-400 text-xs" data-testid="setting-rotation-hint">
+					Screen rotation requires an updated install. Rerun the install script to enable it.
+				</p>
+			{/if}
 		</Field>
 	{/if}
 </div>

--- a/web/src/routes/admin/settings/utils.test.ts
+++ b/web/src/routes/admin/settings/utils.test.ts
@@ -117,6 +117,7 @@ describe('settings utils', () => {
 					blank_after: '20m',
 					backend: 'wlopm',
 					output: 'HDMI-A-1',
+					rotation: 0,
 					locale: 'en-US',
 					hide_clock_date: false,
 					timezone: '',

--- a/web/src/routes/admin/settings/utils.ts
+++ b/web/src/routes/admin/settings/utils.ts
@@ -22,6 +22,7 @@ export function createEmptyConfig(): ConfigResponseBody {
 			blank_after: '20m',
 			backend: 'wlopm',
 			output: 'HDMI-A-1',
+			rotation: 0,
 			locale: 'en-US',
 			hide_clock_date: false,
 			timezone: '',


### PR DESCRIPTION
## Summary

Adds a Rotation setting (0/90/180/270) for portrait mode.
The slideshow adapts on its own: portrait photos fill a portrait screen, landscape photos show as stacked pairs.

Existing installs need to rerun the install script to enable it: rotation depends on a new system tool (wlr-randr) and an updated browser launch script, which in-app software updates do not deliver. Until then the setting shows up disabled with a hint.

Requested in Discussion https://github.com/MateEke/picture-frame/discussions/33.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): summary`).
- [x] `make lint` and `make test` pass locally.
- [x] Tests cover the change, or it needs none (for example, docs only).
- [x] `make generate` run if the API changed.
- [x] No breaking change in a minor or patch release (see CONTRIBUTING).
