### PR TITLE
feat(network): display wired ethernet status

### DIFF
--- a/cmd/picture-frame/wiring.go
+++ b/cmd/picture-frame/wiring.go
@@ -75,13 +75,18 @@ func kioskTimeoutFunc(production bool, log *slog.Logger) func() {
 // dev, or nil (wifi routes then serve 503) when WIFI_MOCK=off.
 func buildWiFiManager(ctx context.Context, log *slog.Logger, cfg *config.Config, production bool, store *config.Store) (httpapi.WiFiManager, error) {
 	if !production {
-		if strings.EqualFold(os.Getenv("WIFI_MOCK"), "off") {
+		hostname, _ := os.Hostname()
+		switch strings.ToLower(os.Getenv("WIFI_MOCK")) {
+		case "off":
 			log.Info("wifi: disabled (development, WIFI_MOCK=off), routes serve 503")
 			return nil, nil
+		case "ethernet":
+			log.Info("wifi: using in-memory ethernet mock (development mode)")
+			return wifimock.NewEthernet(hostname), nil
+		default:
+			log.Info("wifi: using in-memory mock (development mode)")
+			return wifimock.NewDefault(hostname), nil
 		}
-		log.Info("wifi: using in-memory mock (development mode)")
-		hostname, _ := os.Hostname()
-		return wifimock.NewDefault(hostname), nil
 	}
 	if cfg.WiFi.ScanIntervalMinutes <= 0 {
 		return nil, fmt.Errorf("wifi.scan_interval_minutes must be positive")

--- a/internal/wifi/manager.go
+++ b/internal/wifi/manager.go
@@ -16,6 +16,7 @@ type Mode string
 
 const (
 	ModeConnected    Mode = "connected"
+	ModeEthernet     Mode = "ethernet"
 	ModeAP           Mode = "ap"
 	ModeDisconnected Mode = "disconnected"
 	ModeConnecting   Mode = "connecting"
@@ -344,6 +345,22 @@ func (m *Manager) onConnected(ctx context.Context, next WiFiState) time.Duration
 	}
 	link, _ := m.queryActiveWiFi(ctx)
 	m.apTimeoutUntil = time.Time{}
+	if link.ssid == "" {
+		// Blank SSID = no station, hidden station, or query error; only a confirmed-absent station is ethernet.
+		hasWiFi, err := m.hasActiveWiFiStation(ctx)
+		if err != nil || hasWiFi {
+			next.Mode = ModeConnected
+			next.SSID = ""
+			next.IP = ""
+			m.setState(next)
+			return pollInterval
+		}
+		next.Mode = ModeEthernet
+		next.SSID = ""
+		next.IP = m.wiredIP(ctx)
+		m.setState(next)
+		return pollInterval
+	}
 	next.Mode = ModeConnected
 	next.SSID = link.ssid
 	next.IP = link.ip

--- a/internal/wifi/manager_test.go
+++ b/internal/wifi/manager_test.go
@@ -1484,3 +1484,204 @@ func TestConfigureDisableTearsDownActiveAP(t *testing.T) {
 		}
 	})
 }
+
+func setupEthernetFake(f *fakeCommander) {
+	f.set("nmcli -t -f STATE,CONNECTIVITY general status", "connected:full", nil)
+	f.set("nmcli -t -f ACTIVE,SSID,SIGNAL,SECURITY device wifi", "", nil)
+	f.set("nmcli -t -f ACTIVE device wifi", "no\nno", nil)
+	f.set("nmcli -t -f NAME,TYPE,STATE connection show --active", "hotspot:wifi:deactivated", nil)
+	f.set("nmcli connection show hotspot", "connection.id: hotspot", nil)
+	f.set("nmcli connection modify hotspot", "", nil)
+	f.set("nmcli -t -f DEVICE,TYPE,STATE device status",
+		"eth0:ethernet:connected\nwlan0:wifi:disconnected\nlo:loopback:unmanaged", nil)
+	f.set("nmcli -t -f IP4.ADDRESS device show eth0", "IP4.ADDRESS[1]:192.168.1.42/24", nil)
+}
+
+func TestRunEthernetOnBoot(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		f := newFake()
+		setupEthernetFake(f)
+		m := newTestManager(defaultCfg(), f)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go m.Run(ctx)
+		bootWait(t)
+
+		s := m.Status()
+		if s.Mode != ModeEthernet {
+			t.Errorf("mode: got %q, want %q", s.Mode, ModeEthernet)
+		}
+		if s.IP != "192.168.1.42" {
+			t.Errorf("ip: got %q, want 192.168.1.42", s.IP)
+		}
+		if s.SSID != "" || s.Signal != 0 || s.Security != "" {
+			t.Errorf("wifi fields should be empty on ethernet: %+v", s)
+		}
+	})
+}
+
+func TestRunEthernetIPUnresolvedShowsNoIP(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		f := newFake()
+		setupEthernetFake(f)
+		f.set("nmcli -t -f DEVICE,TYPE,STATE device status",
+			"wlan0:wifi:disconnected\nlo:loopback:unmanaged", nil)
+		m := newTestManager(defaultCfg(), f)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go m.Run(ctx)
+		bootWait(t)
+
+		s := m.Status()
+		if s.Mode != ModeEthernet {
+			t.Errorf("mode: got %q, want ethernet", s.Mode)
+		}
+		if s.IP != "" {
+			t.Errorf("ip: got %q, want empty", s.IP)
+		}
+	})
+}
+
+func TestRunEthernetStateVariantTolerated(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		f := newFake()
+		setupEthernetFake(f)
+		f.set("nmcli -t -f DEVICE,TYPE,STATE device status",
+			"eth0:ethernet:connected (externally)\nlo:loopback:unmanaged", nil)
+		m := newTestManager(defaultCfg(), f)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go m.Run(ctx)
+		bootWait(t)
+
+		if s := m.Status(); s.Mode != ModeEthernet || s.IP != "192.168.1.42" {
+			t.Errorf("state = %+v, want ethernet with IP 192.168.1.42", s)
+		}
+	})
+}
+
+func TestEthernetClearsStaleSSID(t *testing.T) {
+	f := newFake()
+	setupEthernetFake(f)
+	m := newTestManager(defaultCfg(), f)
+	m.booted = true
+	m.setState(WiFiState{Mode: ModeConnected, SSID: "OldWiFi", Signal: 70, Security: "WPA2"})
+
+	m.onPoll(context.Background())
+
+	s := m.Status()
+	if s.Mode != ModeEthernet {
+		t.Errorf("mode: got %q, want ethernet", s.Mode)
+	}
+	if s.SSID != "" {
+		t.Errorf("stale ssid not cleared: got %q", s.SSID)
+	}
+}
+
+func TestDualHomedWiFiWins(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		f := newFake()
+		setupEthernetFake(f)
+		f.set("nmcli -t -f ACTIVE,SSID,SIGNAL,SECURITY device wifi", "yes:HomeWiFi:80:WPA2", nil)
+		f.set("nmcli -t -f IP4.ADDRESS device show wlan0", "IP4.ADDRESS[1]:192.168.1.5/24", nil)
+		m := newTestManager(defaultCfg(), f)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go m.Run(ctx)
+		bootWait(t)
+
+		s := m.Status()
+		if s.Mode != ModeConnected || s.SSID != "HomeWiFi" {
+			t.Errorf("dual-homed should show WiFi: mode=%q ssid=%q", s.Mode, s.SSID)
+		}
+		if f.called("DEVICE,TYPE,STATE device status") {
+			t.Error("wired path should not run when a WiFi link is active")
+		}
+	})
+}
+
+func TestConnectedHiddenSSIDNotMisclassified(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		f := newFake()
+		setupEthernetFake(f)
+		f.set("nmcli -t -f ACTIVE,SSID,SIGNAL,SECURITY device wifi", "yes::80:WPA2", nil)
+		f.set("nmcli -t -f ACTIVE device wifi", "yes\nno", nil)
+		m := newTestManager(defaultCfg(), f)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go m.Run(ctx)
+		bootWait(t)
+
+		if s := m.Status(); s.Mode != ModeConnected {
+			t.Errorf("hidden-SSID station must stay connected, got %q", s.Mode)
+		}
+	})
+}
+
+func TestStationQueryErrorNotMisclassified(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		f := newFake()
+		setupEthernetFake(f)
+		f.set("nmcli -t -f ACTIVE device wifi", "", errors.New("nmcli busy"))
+		m := newTestManager(defaultCfg(), f)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go m.Run(ctx)
+		bootWait(t)
+
+		if s := m.Status(); s.Mode == ModeEthernet {
+			t.Error("must not classify ethernet when the station query errors")
+		}
+	})
+}
+
+func TestFirstIP4(t *testing.T) {
+	if got := firstIP4([]byte("IP4.ADDRESS[1]:10.0.0.9/24")); got != "10.0.0.9" {
+		t.Errorf("got %q, want 10.0.0.9", got)
+	}
+	if got := firstIP4([]byte("GENERAL.STATE:100")); got != "" {
+		t.Errorf("got %q, want empty (no IP4.ADDRESS line)", got)
+	}
+	if got := firstIP4(nil); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+func TestWiredIP(t *testing.T) {
+	f := newFake()
+	f.set("nmcli -t -f DEVICE,TYPE,STATE device status", "", errors.New("boom"))
+	if got := newTestManager(defaultCfg(), f).wiredIP(context.Background()); got != "" {
+		t.Errorf("device-status error: got %q, want empty", got)
+	}
+	f2 := newFake()
+	f2.set("nmcli -t -f DEVICE,TYPE,STATE device status", "eth0:ethernet:connected", nil)
+	f2.set("nmcli -t -f IP4.ADDRESS device show eth0", "", errors.New("boom"))
+	if got := newTestManager(defaultCfg(), f2).wiredIP(context.Background()); got != "" {
+		t.Errorf("device-show error: got %q, want empty", got)
+	}
+	f3 := newFake()
+	f3.set("nmcli -t -f DEVICE,TYPE,STATE device status", "bad\neth0:ethernet:connected", nil)
+	f3.set("nmcli -t -f IP4.ADDRESS device show eth0", "GENERAL.STATE:100", nil)
+	if got := newTestManager(defaultCfg(), f3).wiredIP(context.Background()); got != "" {
+		t.Errorf("no IP4 line: got %q, want empty", got)
+	}
+}
+
+func TestHiddenFallbackClearsStaleIP(t *testing.T) {
+	f := newFake()
+	setupEthernetFake(f)
+	f.set("nmcli -t -f ACTIVE device wifi", "yes\nno", nil)
+	m := newTestManager(defaultCfg(), f)
+	m.booted = true
+	m.setState(WiFiState{Mode: ModeConnected, SSID: "Home", IP: "192.168.1.5", Signal: 70, Security: "WPA2"})
+
+	m.onPoll(context.Background())
+
+	s := m.Status()
+	if s.Mode != ModeConnected {
+		t.Errorf("mode: got %q, want connected", s.Mode)
+	}
+	if s.SSID != "" || s.IP != "" {
+		t.Errorf("stale fields not cleared: ssid=%q ip=%q", s.SSID, s.IP)
+	}
+}

--- a/internal/wifi/mock/mock.go
+++ b/internal/wifi/mock/mock.go
@@ -49,6 +49,22 @@ func NewDefault(hostname string) *Manager {
 	)
 }
 
+// NewEthernet seeds a wired connection (no active WiFi link) with the default scan list.
+func NewEthernet(hostname string) *Manager {
+	def := NewDefault(hostname)
+	return New(
+		wifi.WiFiState{
+			Mode:          wifi.ModeEthernet,
+			IP:            "192.168.1.50",
+			APEnabled:     true,
+			APSSID:        "PictureFrame",
+			APHasPassword: true,
+			Hostname:      hostname,
+		},
+		def.networks,
+	)
+}
+
 func (m *Manager) Status() wifi.WiFiState {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/wifi/mock/mock_test.go
+++ b/internal/wifi/mock/mock_test.go
@@ -29,6 +29,20 @@ func TestNewDefaultIsSeeded(t *testing.T) {
 	}
 }
 
+func TestNewEthernetIsSeeded(t *testing.T) {
+	m := NewEthernet("frame")
+	s := m.Status()
+	if s.Mode != wifi.ModeEthernet || s.Hostname != "frame" {
+		t.Errorf("state = %+v, want ethernet with hostname frame", s)
+	}
+	if s.IP == "" {
+		t.Error("ethernet mock should carry an IP")
+	}
+	if nets, _ := m.Scan(context.Background()); len(nets) == 0 {
+		t.Error("ethernet mock network list should not be empty")
+	}
+}
+
 func TestStatusReturnsSeededState(t *testing.T) {
 	m := seeded()
 	if got := m.Status(); got.SSID != "Home" || got.Signal != 70 {

--- a/internal/wifi/query.go
+++ b/internal/wifi/query.go
@@ -235,3 +235,59 @@ func (m *Manager) profileSSID(ctx context.Context, name string) string {
 	}
 	return strings.TrimSpace(string(out))
 }
+
+// hasActiveWiFiStation is true if a WiFi station is active even with a blank (hidden) SSID; err means couldn't tell.
+func (m *Manager) hasActiveWiFiStation(ctx context.Context) (bool, error) {
+	out, err := m.nmcli.Output(ctx, "nmcli", "-t", "-f", "ACTIVE", "device", "wifi")
+	if err != nil {
+		return false, err
+	}
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		if strings.TrimSpace(line) == "yes" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func firstIP4(out []byte) string {
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		fields := parseTerseFields(line)
+		if len(fields) >= 2 && strings.HasPrefix(fields[0], "IP4.ADDRESS") {
+			ip, _, _ := strings.Cut(fields[1], "/")
+			return ip
+		}
+	}
+	return ""
+}
+
+// wiredIP is the best-effort, display-only IPv4 of the wired (ethernet) link; "" on miss/err.
+func (m *Manager) wiredIP(ctx context.Context) string {
+	out, err := m.nmcli.Output(ctx, "nmcli", "-t", "-f", "DEVICE,TYPE,STATE", "device", "status")
+	if err != nil {
+		return ""
+	}
+	dev := ""
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		fields := parseTerseFields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		typ, state := fields[1], fields[2]
+		if typ == "wifi" || typ == "loopback" {
+			continue
+		}
+		if strings.HasPrefix(state, "connected") {
+			dev = fields[0]
+			break
+		}
+	}
+	if dev == "" {
+		return ""
+	}
+	ipOut, err := m.nmcli.Output(ctx, "nmcli", "-t", "-f", "IP4.ADDRESS", "device", "show", dev)
+	if err != nil {
+		return ""
+	}
+	return firstIP4(ipOut)
+}

--- a/web/e2e/server.ts
+++ b/web/e2e/server.ts
@@ -10,6 +10,8 @@ export type ServerOptions = {
 	passwordHash?: string;
 	/** WIFI_MOCK=off → wifi routes serve 503. */
 	wifiOff?: boolean;
+	/** WIFI_MOCK=ethernet → wired connection with no active WiFi link. */
+	wifiEthernet?: boolean;
 	/** Immich library backend (dummy share URL; syncer fails in the background). */
 	immich?: boolean;
 	/** Updater mock: fake newer version offered (unset = up to date). */
@@ -72,6 +74,7 @@ async function spawnOnce(opts: ServerOptions): Promise<PfServer> {
 
 	const env: NodeJS.ProcessEnv = { ...process.env, GO_ENV: 'dev', UPDATER_MOCK_DELAY: '0' };
 	if (opts.wifiOff) env.WIFI_MOCK = 'off';
+	if (opts.wifiEthernet) env.WIFI_MOCK = 'ethernet';
 	if (opts.updateLatest) env.UPDATER_MOCK_LATEST = opts.updateLatest;
 	if (opts.updateOutcome) env.UPDATER_MOCK_OUTCOME = opts.updateOutcome;
 	if (opts.updateOffline) env.UPDATER_MOCK_OFFLINE = '1';

--- a/web/e2e/wifi.spec.ts
+++ b/web/e2e/wifi.spec.ts
@@ -123,3 +123,20 @@ test.describe('wifi unavailable', () => {
 		await expect(wifi.unavailable).toBeVisible();
 	});
 });
+
+test.describe('ethernet connection', () => {
+	test.use({ serverOptions: { wifiEthernet: true } });
+
+	test('wifi page shows an ethernet status card and still lists networks', async ({ wifi }) => {
+		await wifi.goto();
+		await expect(wifi.status).toContainText('Ethernet');
+		await expect(wifi.status).toContainText('192.168.1.50');
+		await wifi.scan.click();
+		await expect(wifi.networks).toHaveCount(7);
+	});
+
+	test('dashboard network tile shows Ethernet, not Disconnected', async ({ dashboard }) => {
+		await dashboard.goto();
+		await expect(dashboard.tileWifi).toContainText('Ethernet');
+	});
+});

--- a/web/src/lib/wifi.test.ts
+++ b/web/src/lib/wifi.test.ts
@@ -9,9 +9,10 @@ import {
 	signalLevel,
 	isWPA3Only,
 	groupNetworks,
-	apPasswordPayload
+	apPasswordPayload,
+	networkTile
 } from './wifi';
-import type { WiFiNetwork } from '$lib/api/types.gen';
+import type { WiFiNetwork, WiFiState } from '$lib/api/types.gen';
 
 vi.mock('./toaster', () => ({
 	toaster: { error: vi.fn(), success: vi.fn() }
@@ -442,6 +443,96 @@ describe('wifi', () => {
 
 		it('returns empty groups for an empty scan', () => {
 			expect(groupNetworks([], null)).toEqual({ saved: [], available: [] });
+		});
+	});
+
+	describe('networkTile', () => {
+		const state = (overrides: Partial<WiFiState>): WiFiState => ({
+			mode: 'connected',
+			ssid: '',
+			ip: '',
+			signal: 0,
+			security: '',
+			ap_enabled: false,
+			ap_has_password: false,
+			ap_ssid: '',
+			hostname: 'frame',
+			...overrides
+		});
+
+		it('labels an ethernet connection with its IP', () => {
+			expect(networkTile(state({ mode: 'ethernet', ip: '192.168.1.42' }))).toEqual({
+				label: 'Ethernet',
+				value: '192.168.1.42',
+				sub: 'Connected',
+				icon: 'ethernet',
+				tone: 'success'
+			});
+		});
+
+		it('falls back to Connected when the ethernet IP is unknown', () => {
+			expect(networkTile(state({ mode: 'ethernet', ip: '' }))).toMatchObject({
+				label: 'Ethernet',
+				value: 'Connected',
+				icon: 'ethernet'
+			});
+		});
+
+		it('keeps the WiFi label and SSID for a wireless connection', () => {
+			expect(networkTile(state({ mode: 'connected', ssid: 'Home' }))).toEqual({
+				label: 'WiFi',
+				value: 'Home',
+				sub: 'Connected',
+				icon: 'wifi',
+				tone: 'success'
+			});
+		});
+
+		it('falls back to Connected for a wireless connection with no SSID', () => {
+			expect(networkTile(state({ mode: 'connected', ssid: '' }))).toMatchObject({
+				value: 'Connected'
+			});
+		});
+
+		it('shows the hotspot SSID in AP mode', () => {
+			expect(networkTile(state({ mode: 'ap', ap_ssid: 'PictureFrame' }))).toEqual({
+				label: 'WiFi',
+				value: 'PictureFrame',
+				sub: 'Hotspot mode',
+				icon: 'wifi',
+				tone: 'success'
+			});
+		});
+
+		it('falls back to Hotspot when the AP SSID is empty', () => {
+			expect(networkTile(state({ mode: 'ap', ap_ssid: '' }))).toMatchObject({ value: 'Hotspot' });
+		});
+
+		it('shows Connecting… while associating', () => {
+			expect(networkTile(state({ mode: 'connecting' }))).toEqual({
+				label: 'WiFi',
+				value: 'Connecting…',
+				icon: 'wifi',
+				tone: 'success'
+			});
+		});
+
+		it('shows Disconnected for a non-null disconnected state', () => {
+			expect(networkTile(state({ mode: 'disconnected' }))).toEqual({
+				label: 'WiFi',
+				value: 'Disconnected',
+				icon: 'wifi',
+				tone: 'success'
+			});
+		});
+
+		it('shows Unavailable with the off icon when status is null', () => {
+			expect(networkTile(null)).toEqual({
+				label: 'WiFi',
+				value: 'Unavailable',
+				icon: 'wifi-off',
+				tone: 'surface'
+			});
 		});
 	});
 

--- a/web/src/lib/wifi.ts
+++ b/web/src/lib/wifi.ts
@@ -7,7 +7,7 @@ import {
 } from '$lib/api/sdk.gen';
 import type { WiFiState, WiFiNetwork } from '$lib/api/types.gen';
 import { toaster } from './toaster';
-export type WiFiMode = 'connected' | 'ap' | 'disconnected' | 'connecting';
+export type WiFiMode = 'connected' | 'ethernet' | 'ap' | 'disconnected' | 'connecting';
 
 export async function loadWiFiStatus(
 	fetch: typeof globalThis.fetch,
@@ -90,6 +90,48 @@ export function signalLevel(signal: number): number {
 
 export function isWPA3Only(security: string): boolean {
 	return security.trim() === 'WPA3';
+}
+
+export type NetworkTileIcon = 'wifi' | 'wifi-off' | 'ethernet';
+
+export interface NetworkTile {
+	label: string;
+	value: string;
+	sub?: string;
+	icon: NetworkTileIcon;
+	tone: 'success' | 'surface';
+}
+
+export function networkTile(w: WiFiState | null): NetworkTile {
+	if (!w) return { label: 'WiFi', value: 'Unavailable', icon: 'wifi-off', tone: 'surface' };
+	if (w.mode === 'ethernet') {
+		return {
+			label: 'Ethernet',
+			value: w.ip || 'Connected',
+			sub: w.ip ? 'Connected' : undefined,
+			icon: 'ethernet',
+			tone: 'success'
+		};
+	}
+	if (w.mode === 'ap')
+		return {
+			label: 'WiFi',
+			value: w.ap_ssid || 'Hotspot',
+			sub: 'Hotspot mode',
+			icon: 'wifi',
+			tone: 'success'
+		};
+	if (w.mode === 'connecting')
+		return { label: 'WiFi', value: 'Connecting…', icon: 'wifi', tone: 'success' };
+	if (w.mode === 'connected')
+		return {
+			label: 'WiFi',
+			value: w.ssid || 'Connected',
+			sub: 'Connected',
+			icon: 'wifi',
+			tone: 'success'
+		};
+	return { label: 'WiFi', value: 'Disconnected', icon: 'wifi', tone: 'success' };
 }
 
 // Maps the AP password field to configureAP's optional password: a typed value

--- a/web/src/routes/admin/+page.svelte
+++ b/web/src/routes/admin/+page.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import type { PageProps } from './$types';
-	import type { WiFiState } from '$lib/api/types.gen';
 	import { onMount } from 'svelte';
 	import { Switch } from '@skeletonlabs/skeleton-svelte';
 	import {
 		WifiIcon,
 		WifiOffIcon,
+		EthernetPortIcon,
 		CloudSunIcon,
 		RadioIcon,
 		ImagesIcon,
@@ -19,6 +19,7 @@
 	import { isSensorStale } from '$lib/helpers';
 	import { formatDuration } from '$lib/duration';
 	import { setScreen } from '$lib/screen';
+	import { networkTile } from '$lib/wifi';
 	import { getSSEContext } from '$lib/sse.svelte';
 	import NowPlaying from './components/NowPlaying.svelte';
 	import StatTile from './components/StatTile.svelte';
@@ -58,14 +59,9 @@
 		toggleScreenBusy = false;
 	}
 
-	function wifiTile(w: WiFiState | null): { value: string; sub?: string } {
-		if (!w) return { value: 'Unavailable' };
-		if (w.mode === 'ap') return { value: w.ap_ssid || 'Hotspot', sub: 'Hotspot mode' };
-		if (w.mode === 'connecting') return { value: 'Connecting…' };
-		if (w.mode === 'connected') return { value: w.ssid || 'Connected', sub: 'Connected' };
-		return { value: 'Disconnected' };
-	}
-	const wifi = $derived(wifiTile(data.wifi));
+	const iconFor = { wifi: WifiIcon, 'wifi-off': WifiOffIcon, ethernet: EthernetPortIcon };
+	const wifi = $derived(networkTile(data.wifi));
+	const wifiIcon = $derived(iconFor[wifi.icon]);
 
 	const weather = $derived.by(() => {
 		const w = sse.weather;
@@ -125,11 +121,11 @@
 		<div class="flex flex-col gap-3 md:h-full">
 			<div class="reveal order-2 grid grid-cols-2 gap-3 delay-75 md:order-1">
 				<StatTile
-					label="WiFi"
+					label={wifi.label}
 					value={wifi.value}
 					sub={wifi.sub}
-					Icon={data.wifi ? WifiIcon : WifiOffIcon}
-					tone={data.wifi ? 'success' : 'surface'}
+					Icon={wifiIcon}
+					tone={wifi.tone}
 					href={resolve('/admin/wifi')}
 					data-testid="tile-wifi"
 				/>

--- a/web/src/routes/admin/wifi/components/StatusCard.svelte
+++ b/web/src/routes/admin/wifi/components/StatusCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Component } from 'svelte';
-	import { WifiIcon, WifiOffIcon, RadioIcon, LoaderIcon } from '@lucide/svelte';
+	import { WifiIcon, WifiOffIcon, RadioIcon, LoaderIcon, EthernetPortIcon } from '@lucide/svelte';
 	import type { WiFiState } from '$lib/api/types.gen';
 	import SignalBars from '$lib/SignalBars.svelte';
 
@@ -31,6 +31,14 @@
 					spin: false,
 					headline: status.ssid,
 					detail: status.security ? `${status.security} secured` : 'Open network'
+				};
+			case 'ethernet':
+				return {
+					icon: EthernetPortIcon,
+					tone: 'success',
+					spin: false,
+					headline: 'Ethernet',
+					detail: status.ip || 'Connected'
 				};
 			case 'ap':
 				return {


### PR DESCRIPTION
## Summary

Closes #58. A wired (ethernet) frame with no WiFi showed a false "WiFi connected" card. Adds an explicit `ethernet` mode (with best-effort wired IP) on the status card and dashboard tile. Hidden-SSID links and nmcli errors stay `connected`.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): summary`).
- [x] `make lint` and `make test` pass locally.
- [x] Tests cover the change, or it needs none (for example, docs only).
- [x] `make generate` run if the API changed.
- [x] No breaking change in a minor or patch release (see CONTRIBUTING).