### PR TITLE
fix(install): fix install script asset downloads on update

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 REPO="MateEke/picture-frame"
 # Trust anchor; must match deploy/minisign.pub and the updater's embedded key.
 MINISIGN_PUBKEY="RWSn8v6e9fllWNQOZr6w2z8ic5NXGHtKMWxjxrjuu3SWj8BpoWxQLtHl"
+# Records which release's payload sits in INSTALL_DIR (binary + deploy/ templates).
+PAYLOAD_MARKER=".release"
 
 DRY_RUN=0
 NON_INTERACTIVE=0
@@ -293,19 +295,27 @@ extract_release() {
     run_cmd mkdir -p "$INSTALL_DIR"
     # Unwrapped: unreachable under --dry-run (fetch_and_verify returns early).
     tar -xzf "$WORKDIR/$TARBALL" -C "$INSTALL_DIR"
+    printf '%s\n' "$RELEASE_TAG" > "$INSTALL_DIR/$PAYLOAD_MARKER"
     run_cmd chown -R "$SERVICE_USER:$SERVICE_USER" "$INSTALL_DIR"
 }
 
+# Marker, not binary version: the self-updater swaps the binary without refreshing deploy/,
+# whose templates this script then reads.
+payload_is_current() {
+    [ -x "$INSTALL_DIR/picture-frame" ] || return 1
+    [ "$(cat "$INSTALL_DIR/$PAYLOAD_MARKER" 2>/dev/null || true)" = "$RELEASE_TAG" ]
+}
+
 fetch_and_verify() {
-    if [ -x "$INSTALL_DIR/picture-frame" ] && [ "$VERSION" = "latest" ]; then
-        log "existing binary at $INSTALL_DIR/picture-frame, skipping download (use --version to force)"
-        return
-    fi
     if [ "$DRY_RUN" -eq 1 ]; then
         log "[dry-run] would resolve/download/verify/extract release '$VERSION' for $ARCH"
         return
     fi
     resolve_release
+    if payload_is_current; then
+        log "$RELEASE_TAG already extracted at $INSTALL_DIR, skipping download"
+        return
+    fi
     download_release
     verify_release
     extract_release

--- a/docs/src/content/docs/getting-started/install.md
+++ b/docs/src/content/docs/getting-started/install.md
@@ -25,7 +25,8 @@ That's the whole thing. The installer:
 - optionally configures a Wi-Fi recovery hotspot and an admin password
 
 It's safe to re-run: it re-applies the system setup but never overwrites an existing
-`config.toml`.
+`config.toml`. A re-run also brings the installed release up to date, so the system setup it
+applies always matches the version it just installed.
 
 ## What it asks
 


### PR DESCRIPTION
<!-- The PR title becomes the squash commit, so write it as a Conventional Commit. -->

## Summary

Install script was not downloading newer assets when no specific version was provided, this PR fixes that issue.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): summary`).
- [x] `make lint` and `make test` pass locally.
- [x] Tests cover the change, or it needs none (for example, docs only).
- [x] `make generate` run if the API changed.
- [x] No breaking change in a minor or patch release (see CONTRIBUTING).
