### PR TITLE
feat(kiosk): drift the overlay to spare OLED panels

### DIFF
--- a/docs/src/content/docs/manual/kiosk.md
+++ b/docs/src/content/docs/manual/kiosk.md
@@ -34,6 +34,11 @@ A reading shows only when its source is configured, and one that has stopped arr
 to `--`. When nothing is left to show, no readings, no weather, and the clock and date hidden, the
 whole bottom overlay disappears and the photo fills the screen on its own.
 
+The clock, date, and readings drift slowly around a small circle, a step each minute and a full
+turn each hour. Each step is about a pixel, too small to notice, and over an hour it keeps an
+OLED panel from wearing the same bright edges into one spot. LCD panels do not need this, but it
+costs them nothing. There is no setting for it.
+
 ## Touching the screen
 
 Touch the left half of the screen for the previous photo, the right half for the next. Either one

--- a/web/e2e/kiosk.spec.ts
+++ b/web/e2e/kiosk.spec.ts
@@ -64,6 +64,94 @@ test.describe('kiosk overlay visibility', () => {
 		});
 	});
 
+	test.describe('burn-in shift', () => {
+		// UTC pins the minute of the hour; half-hour-offset zones would shift it.
+		test.use({ timezoneId: 'UTC' });
+
+		test('offsets the overlay content without moving the scrim', async ({ kiosk, page }) => {
+			// Minute 24: both components non-zero. Readings may show "--" here (the pinned
+			// clock can push them past SENSOR_STALE_MS); this asserts geometry only.
+			const fixed = new Date();
+			fixed.setUTCMinutes(24, 0, 0);
+			await page.clock.setFixedTime(fixed);
+
+			await kiosk.goto();
+			await kiosk.waitForImage();
+
+			const rem = await kiosk.rootFontSize();
+			const clockShift = await kiosk.shiftOf(kiosk.clockBlock);
+
+			// Past a third of the orbit: x negative, y positive.
+			expect(clockShift.x).toBeLessThan(0);
+			expect(clockShift.y).toBeGreaterThan(0);
+			expect(Math.abs(clockShift.x)).toBeLessThanOrEqual(0.75 * rem);
+			expect(Math.abs(clockShift.y)).toBeLessThanOrEqual(0.5 * rem);
+
+			// Whole pixels, or a promoted layer would resample and soften the text.
+			expect(Number.isInteger(clockShift.x)).toBe(true);
+			expect(Number.isInteger(clockShift.y)).toBe(true);
+
+			// Mirrored horizontally so both margins move together; level so the baseline holds.
+			const readingsShift = await kiosk.shiftOf(kiosk.readings);
+			expect(clockShift.x + readingsShift.x).toBe(0);
+			expect(readingsShift.y).toBe(clockShift.y);
+
+			const size = page.viewportSize();
+			if (!size) throw new Error('no viewport size');
+			const overlayBox = await kiosk.overlay.boundingBox();
+			if (!overlayBox) throw new Error('no overlay box');
+			expect(overlayBox.x).toBeCloseTo(0, 0);
+			expect(overlayBox.width).toBeCloseTo(size.width, 0);
+			expect(overlayBox.y + overlayBox.height).toBeCloseTo(size.height, 0);
+
+			for (const block of [kiosk.clockBlock, kiosk.readings]) {
+				const box = await block.boundingBox();
+				if (!box) throw new Error('no block box');
+				expect(box.x).toBeGreaterThan(0);
+				expect(box.y).toBeGreaterThan(0);
+				expect(box.x + box.width).toBeLessThan(size.width);
+				expect(box.y + box.height).toBeLessThan(size.height);
+			}
+		});
+
+		// Either block can be configured away, so each must shift on its own.
+		test.describe('readings only', () => {
+			test.use({ serverOptions: { hideClockDate: true } });
+
+			test('still shifts the surviving block', async ({ kiosk, page }) => {
+				const fixed = new Date();
+				fixed.setUTCMinutes(24, 0, 0);
+				await page.clock.setFixedTime(fixed);
+				await kiosk.goto();
+				await kiosk.waitForImage();
+
+				await expect(kiosk.clockBlock).toHaveCount(0);
+				const shift = await kiosk.shiftOf(kiosk.readings);
+				expect(shift.x).toBeGreaterThan(0);
+				expect(Number.isInteger(shift.x)).toBe(true);
+				expect(Number.isInteger(shift.y)).toBe(true);
+			});
+		});
+
+		test.describe('clock only', () => {
+			test.use({ serverOptions: { minimalOverlay: true } });
+
+			test('still shifts the surviving block', async ({ kiosk, page }) => {
+				const fixed = new Date();
+				fixed.setUTCMinutes(24, 0, 0);
+				await page.clock.setFixedTime(fixed);
+				await kiosk.goto();
+				await kiosk.waitForImage();
+
+				await expect(kiosk.readings).toHaveCount(0);
+				const shift = await kiosk.shiftOf(kiosk.clockBlock);
+				expect(shift.x).toBeLessThan(0);
+				expect(Number.isInteger(shift.x)).toBe(true);
+				expect(Number.isInteger(shift.y)).toBe(true);
+			});
+		});
+	});
+
 	test.describe('timezone', () => {
 		test.use({ serverOptions: { timezone: 'Asia/Tokyo' } });
 

--- a/web/e2e/pages/kiosk.page.ts
+++ b/web/e2e/pages/kiosk.page.ts
@@ -5,6 +5,8 @@ export class KioskPage {
 	readonly imgBottom: Locator;
 	readonly overlay: Locator;
 	readonly clock: Locator;
+	readonly clockBlock: Locator;
+	readonly readings: Locator;
 	readonly date: Locator;
 	readonly tempInside: Locator;
 	readonly tempOutside: Locator;
@@ -20,6 +22,8 @@ export class KioskPage {
 		this.imgBottom = page.getByTestId('kiosk-img-bottom');
 		this.overlay = page.getByTestId('kiosk-overlay');
 		this.clock = page.getByTestId('kiosk-clock');
+		this.clockBlock = page.getByTestId('kiosk-clock-block');
+		this.readings = page.getByTestId('kiosk-readings');
 		this.date = page.getByTestId('kiosk-date');
 		this.tempInside = page.getByTestId('kiosk-temp-inside');
 		this.tempOutside = page.getByTestId('kiosk-temp-outside');
@@ -61,5 +65,20 @@ export class KioskPage {
 	async waitForImageChange(from: string, timeoutMs = 10_000): Promise<string> {
 		await expect(this.imgBottom).not.toHaveAttribute('src', from, { timeout: timeoutMs });
 		return String(await this.currentImageSrc());
+	}
+
+	/** The element's translate, in CSS px. */
+	shiftOf(target: Locator): Promise<{ x: number; y: number }> {
+		return target.evaluate((el) => {
+			const t = getComputedStyle(el).transform;
+			const m = new DOMMatrixReadOnly(t === 'none' ? '' : t);
+			return { x: m.m41, y: m.m42 };
+		});
+	}
+
+	rootFontSize(): Promise<number> {
+		return this.page.evaluate(() =>
+			parseFloat(getComputedStyle(document.documentElement).fontSize)
+		);
 	}
 }

--- a/web/src/routes/kiosk/components/Overlay.svelte
+++ b/web/src/routes/kiosk/components/Overlay.svelte
@@ -9,6 +9,7 @@
 	} from '$lib/helpers';
 	import { onMount } from 'svelte';
 	import { weatherIconFor } from './weather-icons';
+	import { overlayShiftPair } from './overlayShift';
 
 	const sse = getSSEContext();
 
@@ -29,12 +30,18 @@
 	let clock = $derived(formatClockParts(now, locale, timeZone));
 	let weekday = $derived(formatWeekday(now, locale, timeZone));
 	let monthDay = $derived(formatMonthDay(now, locale, timeZone));
+	// Rem scales with resolution (layout.css), so px must be recomputed, not cached.
+	let rootPx = $state(16);
+	let portrait = $state(false);
+	let shift = $derived(overlayShiftPair(now, rootPx, portrait));
 
 	onMount(() => {
 		let timeout: ReturnType<typeof setTimeout>;
 
 		const tick = () => {
 			now = new Date();
+			rootPx = parseFloat(getComputedStyle(document.documentElement).fontSize);
+			portrait = matchMedia('(orientation: portrait)').matches;
 			const msToNextMinute = 60_000 - (now.getSeconds() * 1000 + now.getMilliseconds());
 			timeout = setTimeout(tick, msToNextMinute);
 		};
@@ -63,7 +70,7 @@
 		class="pointer-events-none fixed inset-x-0 bottom-0 flex items-end justify-between bg-linear-to-b from-transparent to-black/30 px-15 pt-33 pb-12 text-kiosk-fg text-shadow-lg/30 portrait:flex-col portrait:items-start portrait:gap-12"
 	>
 		{#if !hideClockDate}
-			<div>
+			<div data-testid="kiosk-clock-block" style="transform: {shift.lead}">
 				<div
 					data-testid="kiosk-clock"
 					class="flex items-baseline text-[7rem] leading-none font-medium tabular-nums"
@@ -92,7 +99,11 @@
 		{/if}
 
 		{#if showReadings}
-			<div class="ml-auto flex gap-9 text-right portrait:ml-0 portrait:text-left">
+			<div
+				data-testid="kiosk-readings"
+				class="ml-auto flex gap-9 text-right portrait:ml-0 portrait:text-left"
+				style="transform: {shift.trail}"
+			>
 				{#if showOutside}
 					<div class="min-w-60 portrait:min-w-0">
 						<div

--- a/web/src/routes/kiosk/components/overlayShift.test.ts
+++ b/web/src/routes/kiosk/components/overlayShift.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { overlayShift, overlayShiftPair, SHIFT_X_REM, SHIFT_Y_REM } from './overlayShift';
+
+function at(minute: number): Date {
+	return new Date(2026, 7, 5, 10, minute, 0, 0);
+}
+
+const REM = 16;
+
+function lead(minute: number, rem = REM): string {
+	return overlayShiftPair(at(minute), rem, false).lead;
+}
+
+function parse(style: string): { x: number; y: number } {
+	const m = /^translate\((-?\d+)px, (-?\d+)px\)$/.exec(style);
+	if (!m) throw new Error(`unparseable transform: ${style}`);
+	return { x: Number(m[1]), y: Number(m[2]) };
+}
+
+describe('overlayShift', () => {
+	describe('overlayShift', () => {
+		it('starts the orbit at the positive x extreme', () => {
+			const { x, y } = overlayShift(at(0));
+			expect(x).toBeCloseTo(SHIFT_X_REM, 6);
+			expect(y).toBeCloseTo(0, 6);
+		});
+
+		it('reaches the positive y extreme at a quarter turn', () => {
+			const { x, y } = overlayShift(at(15));
+			expect(x).toBeCloseTo(0, 6);
+			expect(y).toBeCloseTo(SHIFT_Y_REM, 6);
+		});
+
+		it('reaches the negative x extreme at a half turn', () => {
+			const { x, y } = overlayShift(at(30));
+			expect(x).toBeCloseTo(-SHIFT_X_REM, 6);
+			expect(y).toBeCloseTo(0, 6);
+		});
+
+		it('reaches the negative y extreme at a three-quarter turn', () => {
+			const { x, y } = overlayShift(at(45));
+			expect(x).toBeCloseTo(0, 6);
+			expect(y).toBeCloseTo(-SHIFT_Y_REM, 6);
+		});
+
+		it('wraps to the start on the next hour', () => {
+			expect(overlayShift(new Date(2026, 7, 5, 11, 0, 0, 0))).toEqual(overlayShift(at(0)));
+		});
+
+		it('ignores seconds within a minute', () => {
+			expect(overlayShift(new Date(2026, 7, 5, 10, 24, 59, 999))).toEqual(overlayShift(at(24)));
+		});
+
+		it('visits a distinct position on every step', () => {
+			const seen = new Set<string>();
+			for (let m = 0; m < 60; m++) {
+				const { x, y } = overlayShift(at(m));
+				seen.add(`${x.toFixed(6)},${y.toFixed(6)}`);
+			}
+			expect(seen.size).toBe(60);
+		});
+
+		// Perceptibility budget: ~1.3px per step at 16px/rem.
+		it('never moves more than 0.1rem in one step', () => {
+			for (let m = 0; m < 60; m++) {
+				const a = overlayShift(at(m));
+				const b = overlayShift(at((m + 1) % 60));
+				expect(Math.hypot(b.x - a.x, b.y - a.y)).toBeLessThan(0.1);
+			}
+		});
+	});
+
+	describe('overlayShiftPair', () => {
+		// Hard-coded: asserting against SHIFT_*_REM would be self-referential.
+		it('emits whole pixels at the x extremes', () => {
+			expect(lead(0)).toBe('translate(12px, 0px)');
+			expect(lead(30)).toBe('translate(-12px, 0px)');
+		});
+
+		it('emits whole pixels at the y extremes', () => {
+			expect(lead(15)).toBe('translate(0px, 8px)');
+			expect(lead(45)).toBe('translate(0px, -8px)');
+		});
+
+		it('rounds intermediate positions to whole pixels', () => {
+			expect(lead(24)).toBe('translate(-10px, 5px)');
+		});
+
+		it('never emits a fractional or negative-zero value', () => {
+			for (let m = 0; m < 60; m++) {
+				for (const portrait of [false, true]) {
+					const { lead: l, trail } = overlayShiftPair(at(m), REM, portrait);
+					for (const style of [l, trail]) {
+						expect(style).toMatch(/^translate\(-?\d+px, -?\d+px\)$/);
+						expect(style).not.toContain('-0px');
+					}
+				}
+			}
+		});
+
+		it('spans the full pixel amplitude over one orbit', () => {
+			const xs: number[] = [];
+			const ys: number[] = [];
+			for (let m = 0; m < 60; m++) {
+				const { x, y } = parse(lead(m));
+				xs.push(x);
+				ys.push(y);
+			}
+			expect(Math.max(...xs)).toBe(12);
+			expect(Math.min(...xs)).toBe(-12);
+			expect(Math.max(...ys)).toBe(8);
+			expect(Math.min(...ys)).toBe(-8);
+		});
+
+		it('scales with the root font size', () => {
+			expect(lead(0, 32)).toBe('translate(24px, 0px)');
+		});
+
+		it('mirrors the trailing block across the vertical centre in landscape', () => {
+			expect(overlayShiftPair(at(0), REM, false)).toEqual({
+				lead: 'translate(12px, 0px)',
+				trail: 'translate(-12px, 0px)'
+			});
+			expect(overlayShiftPair(at(24), REM, false)).toEqual({
+				lead: 'translate(-10px, 5px)',
+				trail: 'translate(10px, 5px)'
+			});
+		});
+
+		it('keeps the landscape blocks opposed horizontally and level vertically', () => {
+			for (let m = 0; m < 60; m++) {
+				const { lead: l, trail } = overlayShiftPair(at(m), REM, false);
+				const a = parse(l);
+				const b = parse(trail);
+				expect(a.x + b.x).toBe(0);
+				expect(b.y).toBe(a.y);
+			}
+		});
+
+		it('keeps both portrait blocks in lockstep so they stay left-aligned', () => {
+			for (let m = 0; m < 60; m++) {
+				const { lead: l, trail } = overlayShiftPair(at(m), REM, true);
+				expect(trail).toBe(l);
+			}
+		});
+	});
+});

--- a/web/src/routes/kiosk/components/overlayShift.ts
+++ b/web/src/routes/kiosk/components/overlayShift.ts
@@ -1,0 +1,37 @@
+// The overlay is the only static high-contrast content on screen, so it orbits a
+// small ellipse to spare OLED panels.
+
+/** Horizontal amplitude, in rem. One glyph stem; below that only edges smear, not peak wear. */
+export const SHIFT_X_REM = 0.75;
+/** Vertical amplitude, in rem. Less room below the overlay than beside it. */
+export const SHIFT_Y_REM = 0.5;
+
+/** Offset for the given time, in rem. One orbit per hour. */
+export function overlayShift(date: Date): { x: number; y: number } {
+	const angle = (date.getMinutes() / 60) * 2 * Math.PI;
+	return { x: SHIFT_X_REM * Math.cos(angle), y: SHIFT_Y_REM * Math.sin(angle) };
+}
+
+// Whole pixels: the slides underneath are GPU-promoted, and a fractional translate on
+// a composited layer resamples and softens the text.
+function toStyle(x: number, y: number, rootFontSizePx: number): string {
+	const px = (rem: number): number => Math.round(rem * rootFontSizePx);
+	return `translate(${px(x)}px, ${px(y)}px)`;
+}
+
+/**
+ * Styles for the clock (`lead`) and readings (`trail`). Landscape mirrors `trail`
+ * horizontally so both screen margins move together; portrait stacks them left-aligned,
+ * where mirroring would pull them apart.
+ */
+export function overlayShiftPair(
+	date: Date,
+	rootFontSizePx: number,
+	portrait: boolean
+): { lead: string; trail: string } {
+	const { x, y } = overlayShift(date);
+	return {
+		lead: toStyle(x, y, rootFontSizePx),
+		trail: toStyle(portrait ? x : -x, y, rootFontSizePx)
+	};
+}


### PR DESCRIPTION
<!-- The PR title becomes the squash commit, so write it as a Conventional Commit. -->

## Summary

Moves the clock and readings around a tiny circle, about a pixel a minute, one full turn an hour.  Aims to prevent burn-in of OLED screens.

Closes #80.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): summary`).
- [x] `make lint` and `make test` pass locally.
- [x] Tests cover the change, or it needs none (for example, docs only).
- [x] `make generate` run if the API changed.
- [x] No breaking change in a minor or patch release (see CONTRIBUTING).
