### PR TITLE
fix(ci): pin osv scanner to v2.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,9 +278,11 @@ jobs:
         run: npm ci
 
       # Prebuilt binary, `go run` would compile osv-scanner from scratch (~2min).
+      # Pinned to the Makefile's OSV_SCANNER_VERSION: v2.5.0 drops the npm scope from
+      # CycloneDX components (google/osv-scanner#2978). Bump both together.
       - name: Install osv-scanner
         run: |
-          curl -fsSL https://github.com/google/osv-scanner/releases/latest/download/osv-scanner_linux_amd64 -o "$RUNNER_TEMP/osv-scanner"
+          curl -fsSL https://github.com/google/osv-scanner/releases/download/v2.4.0/osv-scanner_linux_amd64 -o "$RUNNER_TEMP/osv-scanner"
           chmod +x "$RUNNER_TEMP/osv-scanner"
           echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,9 +31,11 @@ jobs:
         run: npm ci
 
       # Prebuilt binary, `go run` would compile osv-scanner from scratch (~2min).
+      # Pinned to the Makefile's OSV_SCANNER_VERSION: v2.5.0 drops the npm scope from
+      # CycloneDX components (google/osv-scanner#2978). Bump both together.
       - name: Install osv-scanner
         run: |
-          curl -fsSL https://github.com/google/osv-scanner/releases/latest/download/osv-scanner_linux_amd64 -o "$RUNNER_TEMP/osv-scanner"
+          curl -fsSL https://github.com/google/osv-scanner/releases/download/v2.4.0/osv-scanner_linux_amd64 -o "$RUNNER_TEMP/osv-scanner"
           chmod +x "$RUNNER_TEMP/osv-scanner"
           echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
 

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,11 @@ mutation-diff: embed-seed ## Mutation testing scoped to changes vs BASE_REF (use
 
 # osv-scanner is huge — compiling it via `go run` costs ~2min in CI, so CI downloads the
 # prebuilt release binary onto PATH first; locally go run's build cache makes it cheap.
-OSV_SCANNER := $(shell command -v osv-scanner 2>/dev/null || echo go run github.com/google/osv-scanner/v2/cmd/osv-scanner@latest)
+# Pinned: v2.5.0 drops the npm scope from CycloneDX components, so @lucide/svelte is
+# queried as plain "svelte" (false positives) and @sveltejs/kit as "kit" (missed CVEs).
+# Unpin once google/osv-scanner#2978 ships. Keep in sync with the CI workflows.
+OSV_SCANNER_VERSION := v2.4.0
+OSV_SCANNER := $(shell command -v osv-scanner 2>/dev/null || echo go run github.com/google/osv-scanner/v2/cmd/osv-scanner@$(OSV_SCANNER_VERSION))
 
 vuln: embed-seed ## Scan dependencies for known vulnerabilities (reachable Go + bundled npm)
 	@echo "==> Scanning Go dependencies (govulncheck, reachability-aware)..."


### PR DESCRIPTION
<!-- The PR title becomes the squash commit, so write it as a Conventional Commit. -->

## Summary

Pin until google/osv-scanner#2978 is resolved.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): summary`).
- [x] `make lint` and `make test` pass locally.
- [x] Tests cover the change, or it needs none (for example, docs only).
- [x] `make generate` run if the API changed.
- [x] No breaking change in a minor or patch release (see CONTRIBUTING).
