### PR TITLE
chore(deps): bump nanoid to clear docs cve

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -5789,9 +5789,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.16",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
 			"funding": [
 				{
 					"type": "github",


### PR DESCRIPTION
<!-- The PR title becomes the squash commit, so write it as a Conventional Commit. -->

## Summary

Clears security advisory by bumping transitive nanoid dep.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): summary`).
- [x] `make lint` and `make test` pass locally.
- [x] Tests cover the change, or it needs none (for example, docs only).
- [x] `make generate` run if the API changed.
- [x] No breaking change in a minor or patch release (see CONTRIBUTING).
