### PR TITLE
fix(build): fix meteocons import build warning

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 import { sveltekit } from '@sveltejs/kit/vite';
 import sbom from 'rollup-plugin-sbom';
-import { meteocons, themeColor } from './src/lib/build/meteocons';
+import { meteocons, themeColor } from './src/lib/build/meteocons.ts';
 
 // anchored to this file, not the cwd, so invoking vite from elsewhere still works
 const kioskCss = fileURLToPath(new URL('./src/routes/kiosk/layout.css', import.meta.url));

--- a/web/vitest.stryker.client.config.ts
+++ b/web/vitest.stryker.client.config.ts
@@ -3,7 +3,7 @@ import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 import { sveltekit } from '@sveltejs/kit/vite';
-import { meteocons, themeColor } from './src/lib/build/meteocons';
+import { meteocons, themeColor } from './src/lib/build/meteocons.ts';
 
 // EXPERIMENT: can Stryker drive the browser `client` project? (sse.svelte.ts only)
 const kioskCss = fileURLToPath(new URL('./src/routes/kiosk/layout.css', import.meta.url));

--- a/web/vitest.stryker.config.ts
+++ b/web/vitest.stryker.config.ts
@@ -2,7 +2,7 @@ import { fileURLToPath } from 'node:url';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vitest/config';
 import { sveltekit } from '@sveltejs/kit/vite';
-import { meteocons, themeColor } from './src/lib/build/meteocons';
+import { meteocons, themeColor } from './src/lib/build/meteocons.ts';
 
 // Stryker-only Vitest config: the node-side `server` project in isolation.
 // Deliberately omits the hey-api plugin (the committed src/lib/api is the test


### PR DESCRIPTION
<!-- The PR title becomes the squash commit, so write it as a Conventional Commit. -->

## Summary

Fixes meteocon import build warnings.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): summary`).
- [x] `make lint` and `make test` pass locally.
- [x] Tests cover the change, or it needs none (for example, docs only).
- [ ] `make generate` run if the API changed.
- [x] No breaking change in a minor or patch release (see CONTRIBUTING).
